### PR TITLE
Add placeholder (...) entries support

### DIFF
--- a/AGENTIC_NAVIGATION_GUIDE.md
+++ b/AGENTIC_NAVIGATION_GUIDE.md
@@ -17,4 +17,5 @@
 - Cargo.toml
 - README.md
 - Specification.md # original project specification document
+- ... # Additional project files (tests, examples, etc.)
 </agentic-navigation-guide>

--- a/README.md
+++ b/README.md
@@ -44,8 +44,33 @@ The main rules are:
 - blank lines are not allowed within the guide block
 - no special paths (`.`, `..`, `./`, `../`)
 - no ordering requirement is imposed
+- placeholder entries (`...`) can be used to indicate unlisted items (see below)
 
 Note that it's *not* an error to omit files and directories from the guide, but it *is* an error to include incorrect entries—the guide *must* be accurate*.
+
+### Placeholder Entries
+
+You can use `...` as a placeholder to indicate that there are additional files or directories not explicitly listed:
+
+```
+<agentic-navigation-guide>
+- src/
+  - main.rs # Entry point
+  - ... # Other source files
+- docs/
+  - README.md
+  - api.md
+  - ... # Additional documentation
+</agentic-navigation-guide>
+```
+
+Rules for placeholders:
+- Written as `...` (three dots)
+- May have an optional comment after it
+- Cannot have child elements nested under them
+- Must refer to at least one unlisted item in the parent directory
+- Cannot be adjacent to another `...` entry (must have at least one non-placeholder between them)
+- Cannot be used in an empty directory
 
 ## Suggested Usage
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -88,6 +88,14 @@ pub enum SyntaxError {
     /// Invalid comment format
     #[error("line {line}: invalid comment format - comments must be separated by '#'")]
     InvalidCommentFormat { line: usize },
+
+    /// Adjacent placeholders
+    #[error("line {line}: placeholder entries (...) cannot be adjacent to each other")]
+    AdjacentPlaceholders { line: usize },
+
+    /// Placeholder with children
+    #[error("line {line}: placeholder entries (...) cannot have child elements")]
+    PlaceholderWithChildren { line: usize },
 }
 
 /// Semantic errors when verifying against filesystem
@@ -131,6 +139,12 @@ pub enum SemanticError {
     /// Permission denied accessing item
     #[error("line {line}: permission denied accessing '{path}'")]
     PermissionDenied { line: usize, path: String },
+
+    /// Placeholder with no unmentioned items
+    #[error(
+        "line {line}: placeholder (...) must refer to at least one unlisted item in '{parent}'"
+    )]
+    PlaceholderNoUnmentionedItems { line: usize, parent: String },
 }
 
 impl SyntaxError {
@@ -147,7 +161,9 @@ impl SyntaxError {
             | Self::InvalidIndentationLevel { line }
             | Self::BlankLineInGuide { line }
             | Self::InvalidPathFormat { line, .. }
-            | Self::InvalidCommentFormat { line } => Some(*line),
+            | Self::InvalidCommentFormat { line }
+            | Self::AdjacentPlaceholders { line }
+            | Self::PlaceholderWithChildren { line } => Some(*line),
             Self::EmptyGuideBlock => None,
         }
     }
@@ -161,7 +177,8 @@ impl SemanticError {
             | Self::TypeMismatch { line, .. }
             | Self::InvalidNesting { line, .. }
             | Self::SymlinkTargetMismatch { line, .. }
-            | Self::PermissionDenied { line, .. } => *line,
+            | Self::PermissionDenied { line, .. }
+            | Self::PlaceholderNoUnmentionedItems { line, .. } => *line,
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -135,7 +135,9 @@ impl Parser {
                 let (path, comment) = self.parse_path_comment(content, line_number)?;
 
                 // Determine item type
-                let item = if path.ends_with('/') {
+                let item = if path == "..." {
+                    FilesystemItem::Placeholder { comment }
+                } else if path.ends_with('/') {
                     FilesystemItem::Directory {
                         path: path.trim_end_matches('/').to_string(),
                         comment,
@@ -181,8 +183,10 @@ impl Parser {
                 .into());
             }
 
-            // Check for special directories
-            if path == "." || path == ".." || path == "./" || path == "../" {
+            // Check for special directories (but allow "..." placeholder)
+            if path == "..." {
+                // Allowed as placeholder
+            } else if path == "." || path == ".." || path == "./" || path == "../" {
                 return Err(SyntaxError::InvalidSpecialDirectory {
                     line: line_number,
                     path,
@@ -359,6 +363,44 @@ mod tests {
             assert_eq!(children[0].path(), "qux.rs");
         } else {
             panic!("baz/ should have children");
+        }
+    }
+
+    #[test]
+    fn test_parse_placeholder() {
+        let content = r#"<agentic-navigation-guide>
+- src/
+  - main.rs
+  - ... # other source files
+- docs/
+  - README.md
+  - ...
+</agentic-navigation-guide>"#;
+
+        let parser = Parser::new();
+        let guide = parser.parse(content).unwrap();
+        assert_eq!(guide.items.len(), 2); // src/ and docs/ at root level
+
+        // Check src/ contains main.rs and a placeholder
+        let src_item = &guide.items[0];
+        if let Some(children) = src_item.children() {
+            assert_eq!(children.len(), 2);
+            assert_eq!(children[0].path(), "main.rs");
+            assert!(children[1].is_placeholder());
+            assert_eq!(children[1].comment(), Some("other source files"));
+        } else {
+            panic!("src/ should have children");
+        }
+
+        // Check docs/ contains README.md and a placeholder
+        let docs_item = &guide.items[1];
+        if let Some(children) = docs_item.children() {
+            assert_eq!(children.len(), 2);
+            assert_eq!(children[0].path(), "README.md");
+            assert!(children[1].is_placeholder());
+            assert_eq!(children[1].comment(), None);
+        } else {
+            panic!("docs/ should have children");
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,6 +31,11 @@ pub enum FilesystemItem {
         /// The target of the symlink (if specified in the guide)
         target: Option<String>,
     },
+    /// A placeholder representing one or more unlisted items
+    Placeholder {
+        /// Optional comment describing what the placeholder represents
+        comment: Option<String>,
+    },
 }
 
 /// Represents a single line in the navigation guide
@@ -51,6 +56,7 @@ impl NavigationGuideLine {
             FilesystemItem::File { path, .. }
             | FilesystemItem::Directory { path, .. }
             | FilesystemItem::Symlink { path, .. } => path,
+            FilesystemItem::Placeholder { .. } => "...",
         }
     }
 
@@ -59,13 +65,19 @@ impl NavigationGuideLine {
         match &self.item {
             FilesystemItem::File { comment, .. }
             | FilesystemItem::Directory { comment, .. }
-            | FilesystemItem::Symlink { comment, .. } => comment.as_deref(),
+            | FilesystemItem::Symlink { comment, .. }
+            | FilesystemItem::Placeholder { comment, .. } => comment.as_deref(),
         }
     }
 
     /// Check if this item is a directory
     pub fn is_directory(&self) -> bool {
         matches!(self.item, FilesystemItem::Directory { .. })
+    }
+
+    /// Check if this item is a placeholder
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self.item, FilesystemItem::Placeholder { .. })
     }
 
     /// Get the children of a directory item

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -33,8 +33,16 @@ impl Validator {
 
     /// Validate a single navigation guide item
     fn validate_item(&self, item: &NavigationGuideLine) -> Result<()> {
-        // Validate path characters
-        self.validate_path_characters(item)?;
+        match &item.item {
+            FilesystemItem::Placeholder { .. } => {
+                // Placeholders don't need path validation
+                // They will have additional validation in validate_placeholders
+            }
+            _ => {
+                // Validate path characters for non-placeholder items
+                self.validate_path_characters(item)?;
+            }
+        }
 
         match &item.item {
             FilesystemItem::Directory { path, children, .. } => {
@@ -52,6 +60,9 @@ impl Validator {
                 for child in children {
                     self.validate_item(child)?;
                 }
+
+                // Check placeholder-specific rules for children
+                self.validate_placeholder_rules(children)?;
             }
             FilesystemItem::File { path, .. } | FilesystemItem::Symlink { path, .. } => {
                 // Files and symlinks should not end with slash
@@ -62,6 +73,9 @@ impl Validator {
                     }
                     .into());
                 }
+            }
+            FilesystemItem::Placeholder { .. } => {
+                // Placeholder-specific validation is done at the parent level
             }
         }
 
@@ -169,6 +183,35 @@ impl Validator {
 
         // Validate proper nesting (no skipping levels)
         self.validate_nesting(items)?;
+
+        // Validate placeholder rules at root level
+        self.validate_placeholder_rules(items)?;
+
+        Ok(())
+    }
+
+    /// Validate placeholder-specific rules
+    fn validate_placeholder_rules(&self, items: &[NavigationGuideLine]) -> Result<()> {
+        // Check that placeholders are not adjacent
+        for i in 0..items.len() {
+            if items[i].is_placeholder() {
+                // Check if next item is also a placeholder
+                if i + 1 < items.len() && items[i + 1].is_placeholder() {
+                    return Err(SyntaxError::AdjacentPlaceholders {
+                        line: items[i + 1].line_number,
+                    }
+                    .into());
+                }
+
+                // Placeholders cannot have children (this should be enforced by parser)
+                if items[i].children().is_some() && !items[i].children().unwrap().is_empty() {
+                    return Err(SyntaxError::PlaceholderWithChildren {
+                        line: items[i].line_number,
+                    }
+                    .into());
+                }
+            }
+        }
 
         Ok(())
     }
@@ -288,5 +331,84 @@ mod tests {
                 SyntaxError::InvalidPathFormat { .. }
             ))
         ));
+    }
+
+    #[test]
+    fn test_validate_adjacent_placeholders() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::Directory {
+                path: "src".to_string(),
+                comment: None,
+                children: vec![
+                    NavigationGuideLine {
+                        line_number: 2,
+                        indent_level: 1,
+                        item: FilesystemItem::Placeholder {
+                            comment: Some("first placeholder".to_string()),
+                        },
+                    },
+                    NavigationGuideLine {
+                        line_number: 3,
+                        indent_level: 1,
+                        item: FilesystemItem::Placeholder {
+                            comment: Some("second placeholder".to_string()),
+                        },
+                    },
+                ],
+            },
+        });
+
+        let validator = Validator::new();
+        let result = validator.validate_syntax(&guide);
+        assert!(matches!(
+            result,
+            Err(crate::errors::AppError::Syntax(
+                SyntaxError::AdjacentPlaceholders { line: 3 }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_validate_non_adjacent_placeholders() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::Directory {
+                path: "src".to_string(),
+                comment: None,
+                children: vec![
+                    NavigationGuideLine {
+                        line_number: 2,
+                        indent_level: 1,
+                        item: FilesystemItem::Placeholder {
+                            comment: Some("first placeholder".to_string()),
+                        },
+                    },
+                    NavigationGuideLine {
+                        line_number: 3,
+                        indent_level: 1,
+                        item: FilesystemItem::File {
+                            path: "main.rs".to_string(),
+                            comment: None,
+                        },
+                    },
+                    NavigationGuideLine {
+                        line_number: 4,
+                        indent_level: 1,
+                        item: FilesystemItem::Placeholder {
+                            comment: Some("second placeholder".to_string()),
+                        },
+                    },
+                ],
+            },
+        });
+
+        let validator = Validator::new();
+        let result = validator.validate_syntax(&guide);
+        assert!(result.is_ok());
     }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -23,9 +23,21 @@ impl Verifier {
         // First validate syntax (should already be done, but double-check)
         crate::validator::Validator::new().validate_syntax(guide)?;
 
+        // Collect mentioned root-level names for placeholder verification
+        let mut mentioned_names = std::collections::HashSet::new();
+        for item in &guide.items {
+            if !item.is_placeholder() {
+                mentioned_names.insert(item.path().to_string());
+            }
+        }
+
         // Then verify each item against the filesystem
         for item in &guide.items {
-            self.verify_item(item, &self.root_path)?;
+            if item.is_placeholder() {
+                self.verify_placeholder_with_context(item, &self.root_path, &mentioned_names)?;
+            } else {
+                self.verify_item(item, &self.root_path)?;
+            }
         }
 
         Ok(())
@@ -33,6 +45,11 @@ impl Verifier {
 
     /// Verify a single item against the filesystem
     fn verify_item(&self, item: &NavigationGuideLine, parent_path: &Path) -> Result<()> {
+        // Handle placeholders specially
+        if item.is_placeholder() {
+            return self.verify_placeholder(item, parent_path);
+        }
+
         let item_path = parent_path.join(item.path());
 
         // Check if the item exists
@@ -64,8 +81,19 @@ impl Verifier {
                 }
 
                 // Verify children recursively
+                let mut mentioned_names = std::collections::HashSet::new();
                 for child in children {
-                    self.verify_item(child, &item_path)?;
+                    if !child.is_placeholder() {
+                        mentioned_names.insert(child.path().to_string());
+                    }
+                }
+
+                for child in children {
+                    if child.is_placeholder() {
+                        self.verify_placeholder_with_context(child, &item_path, &mentioned_names)?;
+                    } else {
+                        self.verify_item(child, &item_path)?;
+                    }
                 }
             }
             FilesystemItem::File { .. } => {
@@ -125,6 +153,11 @@ impl Verifier {
                     }
                 }
             }
+            FilesystemItem::Placeholder { .. } => {
+                // This case should never be reached because we handle placeholders
+                // at the beginning of the function, but we need it for exhaustiveness
+                unreachable!("Placeholder should have been handled earlier");
+            }
         }
 
         Ok(())
@@ -136,7 +169,57 @@ impl Verifier {
             FilesystemItem::Directory { .. } => "directory".to_string(),
             FilesystemItem::File { .. } => "file".to_string(),
             FilesystemItem::Symlink { .. } => "symlink".to_string(),
+            FilesystemItem::Placeholder { .. } => "placeholder".to_string(),
         }
+    }
+
+    /// Verify a placeholder at the root level
+    fn verify_placeholder(&self, item: &NavigationGuideLine, parent_path: &Path) -> Result<()> {
+        // For root-level placeholders, we need to check that there's at least one item
+        // in the parent directory that isn't mentioned in the guide
+        let mentioned_names = std::collections::HashSet::new();
+        self.verify_placeholder_with_context(item, parent_path, &mentioned_names)
+    }
+
+    /// Verify a placeholder with context of mentioned sibling items
+    fn verify_placeholder_with_context(
+        &self,
+        item: &NavigationGuideLine,
+        parent_path: &Path,
+        mentioned_names: &std::collections::HashSet<String>,
+    ) -> Result<()> {
+        // Check that the parent directory has at least one item not in mentioned_names
+        let entries = match std::fs::read_dir(parent_path) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                return Err(SemanticError::PermissionDenied {
+                    line: item.line_number,
+                    path: parent_path.to_string_lossy().to_string(),
+                }
+                .into());
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        // Count unmentioned items
+        let mut unmentioned_count = 0;
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if !mentioned_names.contains(name) {
+                    unmentioned_count += 1;
+                }
+            }
+        }
+
+        if unmentioned_count == 0 {
+            return Err(SemanticError::PlaceholderNoUnmentionedItems {
+                line: item.line_number,
+                parent: parent_path.to_string_lossy().to_string(),
+            }
+            .into());
+        }
+
+        Ok(())
     }
 }
 
@@ -168,6 +251,171 @@ mod tests {
             result,
             Err(crate::errors::AppError::Semantic(
                 SemanticError::ItemNotFound { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_verify_placeholder_with_unmentioned_items() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create files in temp directory
+        std::fs::write(temp_dir.path().join("main.rs"), "").unwrap();
+        std::fs::write(temp_dir.path().join("lib.rs"), "").unwrap();
+        std::fs::write(temp_dir.path().join("mod.rs"), "").unwrap();
+
+        let verifier = Verifier::new(temp_dir.path());
+
+        let guide = NavigationGuide {
+            items: vec![
+                NavigationGuideLine {
+                    line_number: 1,
+                    indent_level: 0,
+                    item: FilesystemItem::File {
+                        path: "main.rs".to_string(),
+                        comment: None,
+                    },
+                },
+                NavigationGuideLine {
+                    line_number: 2,
+                    indent_level: 0,
+                    item: FilesystemItem::Placeholder {
+                        comment: Some("other source files".to_string()),
+                    },
+                },
+            ],
+            prologue: None,
+            epilogue: None,
+        };
+
+        // Should succeed because lib.rs and mod.rs are unmentioned
+        let result = verifier.verify(&guide);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_placeholder_without_unmentioned_items() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create only one file
+        std::fs::write(temp_dir.path().join("main.rs"), "").unwrap();
+
+        let verifier = Verifier::new(temp_dir.path());
+
+        let guide = NavigationGuide {
+            items: vec![
+                NavigationGuideLine {
+                    line_number: 1,
+                    indent_level: 0,
+                    item: FilesystemItem::File {
+                        path: "main.rs".to_string(),
+                        comment: None,
+                    },
+                },
+                NavigationGuideLine {
+                    line_number: 2,
+                    indent_level: 0,
+                    item: FilesystemItem::Placeholder {
+                        comment: Some("other files".to_string()),
+                    },
+                },
+            ],
+            prologue: None,
+            epilogue: None,
+        };
+
+        // Should fail because all items are mentioned
+        let result = verifier.verify(&guide);
+        assert!(matches!(
+            result,
+            Err(crate::errors::AppError::Semantic(
+                SemanticError::PlaceholderNoUnmentionedItems { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_verify_placeholder_in_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("src");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create files in src directory
+        std::fs::write(src_dir.join("main.rs"), "").unwrap();
+        std::fs::write(src_dir.join("lib.rs"), "").unwrap();
+        std::fs::write(src_dir.join("utils.rs"), "").unwrap();
+
+        let verifier = Verifier::new(temp_dir.path());
+
+        let guide = NavigationGuide {
+            items: vec![NavigationGuideLine {
+                line_number: 1,
+                indent_level: 0,
+                item: FilesystemItem::Directory {
+                    path: "src".to_string(),
+                    comment: None,
+                    children: vec![
+                        NavigationGuideLine {
+                            line_number: 2,
+                            indent_level: 1,
+                            item: FilesystemItem::File {
+                                path: "main.rs".to_string(),
+                                comment: None,
+                            },
+                        },
+                        NavigationGuideLine {
+                            line_number: 3,
+                            indent_level: 1,
+                            item: FilesystemItem::Placeholder {
+                                comment: Some("other modules".to_string()),
+                            },
+                        },
+                    ],
+                },
+            }],
+            prologue: None,
+            epilogue: None,
+        };
+
+        // Should succeed because lib.rs and utils.rs are unmentioned
+        let result = verifier.verify(&guide);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_placeholder_in_empty_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("src");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        let verifier = Verifier::new(temp_dir.path());
+
+        let guide = NavigationGuide {
+            items: vec![NavigationGuideLine {
+                line_number: 1,
+                indent_level: 0,
+                item: FilesystemItem::Directory {
+                    path: "src".to_string(),
+                    comment: None,
+                    children: vec![NavigationGuideLine {
+                        line_number: 2,
+                        indent_level: 1,
+                        item: FilesystemItem::Placeholder {
+                            comment: Some("future files".to_string()),
+                        },
+                    }],
+                },
+            }],
+            prologue: None,
+            epilogue: None,
+        };
+
+        // Should fail because directory is empty
+        let result = verifier.verify(&guide);
+        assert!(matches!(
+            result,
+            Err(crate::errors::AppError::Semantic(
+                SemanticError::PlaceholderNoUnmentionedItems { .. }
             ))
         ));
     }


### PR DESCRIPTION
## Summary
- Implements support for placeholder entries (`...`) in navigation guides
- Allows indicating the presence of unlisted files without explicit enumeration
- Adds comprehensive validation and error handling for placeholder rules

## Changes
- Added `Placeholder` variant to `FilesystemItem` enum
- Updated parser to recognize `...` as placeholder syntax
- Implemented syntax validation:
  - Placeholders cannot have children
  - Placeholders cannot be adjacent to each other
- Implemented semantic validation:
  - Placeholders must refer to at least one unlisted item
  - Cannot be used in empty directories
- Added comprehensive unit tests for all placeholder functionality
- Updated README.md with usage examples and rules

## Example Usage
```markdown
<agentic-navigation-guide>
- src/
  - main.rs # Entry point
  - ... # Other source files
- docs/
  - README.md
  - api.md
  - ... # Additional documentation
</agentic-navigation-guide>
```

## Test Plan
- [x] All existing tests pass
- [x] New unit tests for placeholder parsing
- [x] New unit tests for placeholder syntax validation
- [x] New unit tests for placeholder semantic validation
- [x] Manual testing with valid and invalid placeholder usage
- [x] `cargo fmt` and `cargo clippy` pass without warnings

🤖 Generated with [Claude Code](https://claude.ai/code)