### PR TITLE
Refactor to use clap's built-in env attribute for environment variables

### DIFF
--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -11,15 +11,15 @@ use std::path::PathBuf;
 #[derive(Args, Debug)]
 pub struct CheckArgs {
     /// Path to the navigation guide file
-    #[arg(short, long)]
+    #[arg(short, long, env = "AGENTIC_NAVIGATION_GUIDE_PATH")]
     pub guide: Option<PathBuf>,
 
     /// Running as post-tool-use hook
-    #[arg(long)]
+    #[arg(long, conflicts_with = "execution_mode")]
     pub post_tool_use_hook: bool,
 
     /// Running as pre-commit hook
-    #[arg(long)]
+    #[arg(long, conflicts_with = "execution_mode")]
     pub pre_commit_hook: bool,
 }
 
@@ -36,11 +36,6 @@ impl CheckArgs {
         // Determine guide path
         let guide_path = self
             .guide
-            .or_else(|| {
-                std::env::var("AGENTIC_NAVIGATION_GUIDE_PATH")
-                    .ok()
-                    .map(PathBuf::from)
-            })
             .or_else(|| {
                 std::env::var("AGENTIC_NAVIGATION_GUIDE_NAME")
                     .ok()

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -15,11 +15,11 @@ pub struct CheckArgs {
     pub guide: Option<PathBuf>,
 
     /// Running as post-tool-use hook
-    #[arg(long, conflicts_with = "execution_mode")]
+    #[arg(long, conflicts_with_all = ["execution_mode", "pre_commit_hook"])]
     pub post_tool_use_hook: bool,
 
     /// Running as pre-commit hook
-    #[arg(long, conflicts_with = "execution_mode")]
+    #[arg(long, conflicts_with_all = ["execution_mode", "post_tool_use_hook"])]
     pub pre_commit_hook: bool,
 }
 

--- a/src/cli/dump.rs
+++ b/src/cli/dump.rs
@@ -31,7 +31,7 @@ pub struct DumpArgs {
     pub omit_xml_wrapper: bool,
 
     /// Root directory to dump
-    #[arg(short, long)]
+    #[arg(short, long, env = "AGENTIC_NAVIGATION_GUIDE_ROOT")]
     pub root: Option<PathBuf>,
 }
 
@@ -41,11 +41,6 @@ impl DumpArgs {
         // Determine root path
         let root_path = self
             .root
-            .or_else(|| {
-                std::env::var("AGENTIC_NAVIGATION_GUIDE_ROOT")
-                    .ok()
-                    .map(PathBuf::from)
-            })
             .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
 
         log::debug!("Dumping directory: {}", root_path.display());

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -26,7 +26,7 @@ pub struct InitArgs {
     pub indent: usize,
 
     /// Root directory to dump
-    #[arg(short, long)]
+    #[arg(short, long, env = "AGENTIC_NAVIGATION_GUIDE_ROOT")]
     pub root: Option<PathBuf>,
 }
 
@@ -44,11 +44,6 @@ impl InitArgs {
         // Determine root path
         let root_path = self
             .root
-            .or_else(|| {
-                std::env::var("AGENTIC_NAVIGATION_GUIDE_ROOT")
-                    .ok()
-                    .map(PathBuf::from)
-            })
             .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
 
         log::info!("Initializing navigation guide for: {}", root_path.display());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,12 +18,33 @@ use clap::{Parser, Subcommand};
 )]
 pub struct Cli {
     /// Enable verbose output
-    #[arg(short, long, global = true)]
+    #[arg(short, long, global = true, conflicts_with_all = ["quiet", "log_level"])]
     pub verbose: bool,
 
     /// Enable quiet output (minimal messages)
-    #[arg(short, long, global = true)]
+    #[arg(short, long, global = true, conflicts_with_all = ["verbose", "log_level"])]
     pub quiet: bool,
+
+    /// Set log level directly
+    #[arg(
+        long,
+        global = true,
+        env = "AGENTIC_NAVIGATION_GUIDE_LOG_MODE",
+        value_parser = ["quiet", "default", "verbose"],
+        hide = true,
+        conflicts_with_all = ["verbose", "quiet"]
+    )]
+    pub log_level: Option<String>,
+
+    /// Set execution mode directly
+    #[arg(
+        long,
+        global = true,
+        env = "AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE",
+        value_parser = ["default", "post-tool-use", "pre-commit-hook"],
+        hide = true
+    )]
+    pub execution_mode: Option<String>,
 
     /// Subcommand to execute
     #[command(subcommand)]
@@ -49,28 +70,31 @@ pub enum Command {
 impl Cli {
     /// Parse CLI arguments and environment variables into a Config
     pub fn build_config(&self) -> Config {
-        let log_level = if self.verbose {
-            LogLevel::Verbose
-        } else if self.quiet {
-            LogLevel::Quiet
-        } else {
-            LogLevel::Default
-        };
-
-        // Check environment variable for log level override
-        let log_level = std::env::var("AGENTIC_NAVIGATION_GUIDE_LOG_MODE")
-            .ok()
-            .and_then(|mode| match mode.as_str() {
+        // First resolve log level from the direct parameter
+        let log_level = self
+            .log_level
+            .as_ref()
+            .and_then(|level| match level.as_str() {
                 "quiet" => Some(LogLevel::Quiet),
                 "verbose" => Some(LogLevel::Verbose),
                 "default" => Some(LogLevel::Default),
                 _ => None,
             })
-            .unwrap_or(log_level);
+            .unwrap_or({
+                // Then check convenience flags as overrides
+                if self.verbose {
+                    LogLevel::Verbose
+                } else if self.quiet {
+                    LogLevel::Quiet
+                } else {
+                    LogLevel::Default
+                }
+            });
 
-        // Check execution mode from environment
-        let execution_mode = std::env::var("AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE")
-            .ok()
+        // Resolve execution mode from the direct parameter
+        let execution_mode = self
+            .execution_mode
+            .as_ref()
             .and_then(|mode| match mode.as_str() {
                 "post-tool-use" => Some(ExecutionMode::PostToolUse),
                 "pre-commit-hook" => Some(ExecutionMode::PreCommitHook),

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -20,11 +20,11 @@ pub struct VerifyArgs {
     pub root: Option<PathBuf>,
 
     /// Running as post-tool-use hook
-    #[arg(long, conflicts_with = "execution_mode")]
+    #[arg(long, conflicts_with_all = ["execution_mode", "pre_commit_hook"])]
     pub post_tool_use_hook: bool,
 
     /// Running as pre-commit hook
-    #[arg(long, conflicts_with = "execution_mode")]
+    #[arg(long, conflicts_with_all = ["execution_mode", "post_tool_use_hook"])]
     pub pre_commit_hook: bool,
 }
 

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -12,19 +12,19 @@ use std::path::{Path, PathBuf};
 #[derive(Args, Debug)]
 pub struct VerifyArgs {
     /// Path to the navigation guide file
-    #[arg(short, long)]
+    #[arg(short, long, env = "AGENTIC_NAVIGATION_GUIDE_PATH")]
     pub guide: Option<PathBuf>,
 
     /// Root directory for verification
-    #[arg(short, long)]
+    #[arg(short, long, env = "AGENTIC_NAVIGATION_GUIDE_ROOT")]
     pub root: Option<PathBuf>,
 
     /// Running as post-tool-use hook
-    #[arg(long)]
+    #[arg(long, conflicts_with = "execution_mode")]
     pub post_tool_use_hook: bool,
 
     /// Running as pre-commit hook
-    #[arg(long)]
+    #[arg(long, conflicts_with = "execution_mode")]
     pub pre_commit_hook: bool,
 }
 
@@ -43,23 +43,13 @@ impl VerifyArgs {
             .guide
             .as_ref()
             .map(|p| p.display().to_string())
-            .or_else(|| std::env::var("AGENTIC_NAVIGATION_GUIDE_PATH").ok())
             .or_else(|| std::env::var("AGENTIC_NAVIGATION_GUIDE_NAME").ok());
 
-        config.original_root_path = self
-            .root
-            .as_ref()
-            .map(|p| p.display().to_string())
-            .or_else(|| std::env::var("AGENTIC_NAVIGATION_GUIDE_ROOT").ok());
+        config.original_root_path = self.root.as_ref().map(|p| p.display().to_string());
 
         // Determine guide path
         let guide_path = self
             .guide
-            .or_else(|| {
-                std::env::var("AGENTIC_NAVIGATION_GUIDE_PATH")
-                    .ok()
-                    .map(PathBuf::from)
-            })
             .or_else(|| {
                 std::env::var("AGENTIC_NAVIGATION_GUIDE_NAME")
                     .ok()
@@ -74,11 +64,6 @@ impl VerifyArgs {
         // Determine root path
         let root_path = self
             .root
-            .or_else(|| {
-                std::env::var("AGENTIC_NAVIGATION_GUIDE_ROOT")
-                    .ok()
-                    .map(PathBuf::from)
-            })
             .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
 
         log::debug!(


### PR DESCRIPTION
## Summary
- Replaced all ad-hoc environment variable handling with clap's built-in `env` attribute
- Added hidden global parameters for execution mode and log level configuration
- Cleaned up redundant `std::env::var()` calls throughout the codebase

## Changes

### Added hidden global parameters
- `--log-level`: Reads from `AGENTIC_NAVIGATION_GUIDE_LOG_MODE` (values: quiet, default, verbose)
- `--execution-mode`: Reads from `AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE` (values: default, post-tool-use, pre-commit-hook)
- Both parameters are hidden from help output and have proper conflict resolution with convenience flags

### Updated command arguments
- **VerifyArgs**: 
  - `guide` parameter now uses `env = "AGENTIC_NAVIGATION_GUIDE_PATH"`
  - `root` parameter now uses `env = "AGENTIC_NAVIGATION_GUIDE_ROOT"`
- **CheckArgs**: 
  - `guide` parameter now uses `env = "AGENTIC_NAVIGATION_GUIDE_PATH"`
- **DumpArgs**: 
  - `root` parameter now uses `env = "AGENTIC_NAVIGATION_GUIDE_ROOT"`
- **InitArgs**: 
  - `root` parameter now uses `env = "AGENTIC_NAVIGATION_GUIDE_ROOT"`

### Implementation details
- Removed all manual `std::env::var()` calls for the above parameters
- Implemented proper conflict resolution between convenience flags (`--verbose`, `--quiet`) and the hidden `--log-level` parameter
- Preserved the `AGENTIC_NAVIGATION_GUIDE_NAME` fallback logic as a special case
- Updated `Cli::build_config()` to use the new parameter-based approach

## Testing
- ✅ All existing tests pass
- ✅ Environment variables are correctly read and displayed in help output
- ✅ Conflict detection between flags works as expected
- ✅ Code passes `cargo fmt` and `cargo clippy -- -D warnings`

## Benefits
- Cleaner, more maintainable code
- Better consistency by leveraging clap's built-in functionality
- Environment variable values are now visible in help output
- Reduced boilerplate code

🤖 Generated with [Claude Code](https://claude.ai/code)