### PR TITLE
feat: add Claude Code plugin for navigation guide maintenance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "agentic-navigation-guide-marketplace",
+  "owner": {
+    "name": "plx",
+    "email": "plxgithub@gmail.com"
+  },
+  "metadata": {
+    "description": "Plugin marketplace for the agentic-navigation-guide CLI tool",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "agentic-navigation-guide",
+      "source": "./plugins/agentic-navigation-guide",
+      "description": "Skills, hooks, and agents for maintaining agentic navigation guides",
+      "version": "1.0.0",
+      "author": { "name": "plx" },
+      "repository": "https://github.com/plx/agentic-navigation-guide",
+      "license": "MIT",
+      "keywords": ["navigation", "codebase", "documentation", "file-structure"]
+    }
+  ]
+}

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -1,0 +1,93 @@
+name: Validate Plugin
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'plugins/**'
+      - '.claude-plugin/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'plugins/**'
+      - '.claude-plugin/**'
+
+jobs:
+  validate:
+    name: Validate Plugin Structure
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Validate marketplace.json
+      run: |
+        echo "Checking marketplace.json..."
+        jq . .claude-plugin/marketplace.json > /dev/null
+        echo "✓ marketplace.json is valid JSON"
+
+        # Check required fields
+        jq -e '.name' .claude-plugin/marketplace.json > /dev/null
+        echo "✓ marketplace.json has name"
+        jq -e '.owner.name' .claude-plugin/marketplace.json > /dev/null
+        echo "✓ marketplace.json has owner"
+        jq -e '.plugins | length > 0' .claude-plugin/marketplace.json > /dev/null
+        echo "✓ marketplace.json has plugins"
+
+    - name: Validate plugin.json
+      run: |
+        PLUGIN_DIR="plugins/agentic-navigation-guide"
+        echo "Checking $PLUGIN_DIR/.claude-plugin/plugin.json..."
+        jq . "$PLUGIN_DIR/.claude-plugin/plugin.json" > /dev/null
+        echo "✓ plugin.json is valid JSON"
+
+        jq -e '.name' "$PLUGIN_DIR/.claude-plugin/plugin.json" > /dev/null
+        echo "✓ plugin.json has name"
+        jq -e '.description' "$PLUGIN_DIR/.claude-plugin/plugin.json" > /dev/null
+        echo "✓ plugin.json has description"
+
+    - name: Validate hooks.json
+      run: |
+        HOOKS="plugins/agentic-navigation-guide/hooks/hooks.json"
+        echo "Checking $HOOKS..."
+        jq . "$HOOKS" > /dev/null
+        echo "✓ hooks.json is valid JSON"
+        jq -e '.hooks' "$HOOKS" > /dev/null
+        echo "✓ hooks.json has hooks field"
+
+    - name: Check skill directories
+      run: |
+        SKILLS_DIR="plugins/agentic-navigation-guide/skills"
+        ERRORS=0
+        for skill_dir in "$SKILLS_DIR"/*/; do
+          skill_name="$(basename "$skill_dir")"
+          if [[ ! -f "$skill_dir/SKILL.md" ]]; then
+            echo "✗ Missing SKILL.md in $skill_name"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "✓ $skill_name/SKILL.md exists"
+          fi
+        done
+        if [[ $ERRORS -gt 0 ]]; then
+          echo "Found $ERRORS missing SKILL.md files"
+          exit 1
+        fi
+
+    - name: Check agent files
+      run: |
+        AGENTS_DIR="plugins/agentic-navigation-guide/agents"
+        for agent_file in "$AGENTS_DIR"/*.md; do
+          if [[ -f "$agent_file" ]]; then
+            echo "✓ $(basename "$agent_file") exists"
+          fi
+        done
+
+    - name: Check hook script
+      run: |
+        SCRIPT="plugins/agentic-navigation-guide/bin/verify-guide.sh"
+        if [[ ! -x "$SCRIPT" ]]; then
+          echo "✗ $SCRIPT is not executable"
+          exit 1
+        fi
+        echo "✓ verify-guide.sh is executable"
+        bash -n "$SCRIPT"
+        echo "✓ verify-guide.sh passes syntax check"

--- a/AGENTIC_NAVIGATION_GUIDE.md
+++ b/AGENTIC_NAVIGATION_GUIDE.md
@@ -17,5 +17,31 @@
 - Cargo.toml
 - README.md
 - Specification.md # original project specification document
+- plugins/
+  - agentic-navigation-guide/ # Claude Code plugin for navigation guide maintenance
+    - .claude-plugin/
+      - plugin.json
+    - agents/
+      - nav-guide-evaluator.md # Haiku agent for fast file/dir decisions
+      - nav-guide-worker.md # Sonnet agent for guide authoring and repair
+    - skills/
+      - nav-guide-reference/ # Reference docs (non-user-invocable)
+      - should-include-file/ # File inclusion decision
+      - should-include-dir/ # Directory inclusion decision
+      - describe-file/ # Generate terse file description
+      - describe-dir/ # Generate terse directory description
+      - audit-description/ # Verify file description accuracy
+      - audit-dir-description/ # Verify directory description accuracy
+      - evaluate-structure/ # Flat vs nested guide strategy
+      - navigation-guide-repair/ # Fix guide from problem description
+      - guide-search/ # Find relevant files from guide
+      - generate-guide/ # Create initial navigation guide
+      - audit-guide/ # Audit existing guide for staleness
+    - hooks/
+      - hooks.json # PostToolUse and Stop hook config
+    - bin/
+      - verify-guide.sh # Hook helper script
+- .claude-plugin/
+  - marketplace.json # Plugin marketplace catalog
 - ... # Additional project files (tests, examples, etc.)
 </agentic-navigation-guide>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,4 +107,4 @@ These environment variables are used to configure the `agentic-navigation-guide`
 - `AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE`: Set to "post-tool-use", "pre-commit-hook", "github-actions", or "default"
 - `AGENTIC_NAVIGATION_GUIDE_PATH`: Default path to guide file
 - `AGENTIC_NAVIGATION_GUIDE_ROOT`: Default root directory for operations
-- `AGENTIC_NAVIGATION_GUIDE_NAME`: Default guide filename for recursive mode (e.g., "GUIDE.md")
+- `AGENTIC_NAVIGATION_GUIDE_NAME`: Default guide filename when `--guide` is not specified (e.g., "GUIDE.md")

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The tool provides the following commands:
 
 If you're adding a navigation guide to your repository, I'd suggest:
 
-- run `agentic-navigation-guide init` to generate a starting point
+- run `agentic-navigation-guide init --output AGENTIC_NAVIGATION_GUIDE.md` to generate a starting point
 - hand-edit the file to add comments and omit extraneous details
 - run `agentic-navigation-guide verify` to check for errors
 - commit the file to your repository

--- a/Specification.md
+++ b/Specification.md
@@ -243,7 +243,7 @@ If `--guide` is not specified, the following defaults are used, in this order of
 
 Internally these can be represented as a 4-way "mode" enum like `default | post-tool-use | pre-commit-hook | github-actions`; the value of this enum can also be controlled by an environment variable (e.g. `AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE`).
 
-There is a single positional argument: the path to the `AGENTIC_NAVIGATION_GUIDE.md` file (default, if unspecified: the file at the `AGENTIC_NAVIGATION_GUIDE_PATH` environment variable, if set; otherwise, `AGENTIC_NAVIGATION_GUIDE.md` in the current directory).
+There is a single positional argument: the path to the `AGENTIC_NAVIGATION_GUIDE.md` file (default, if unspecified: the file at the `AGENTIC_NAVIGATION_GUIDE_PATH` environment variable, if set; the file named by `AGENTIC_NAVIGATION_GUIDE_NAME` in the current directory, if set; otherwise, `AGENTIC_NAVIGATION_GUIDE.md` in the current directory).
 
 If the file is valid, in default mode (and quiet mode) the command prints nothing to stdout, nothing to stderr, and exits with a 0 exit code.
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,161 @@
+# Automated GitHub issue resolution with Claude Code
+#
+# Exit codes for have-claude-tackle-next-issue-with-labels:
+#   0 = successfully launched Claude to tackle an issue
+#   2 = no matching issues found ("nothing to do")
+#   1 = error
+
+set fallback := false
+
+# Tackle the highest-priority open issue matching the given labels
+have-claude-tackle-next-issue-with-labels *labels:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    labels="{{labels}}"
+    if [[ -z "$labels" ]]; then
+        echo "Error: at least one label is required"
+        exit 1
+    fi
+
+    # Build --label flags for gh CLI
+    label_args=()
+    for label in $labels; do
+        label_args+=(--label "$label")
+    done
+
+    # Fetch open issues with all specified labels
+    issues=$(gh issue list "${label_args[@]}" --state open \
+        --json number,title,labels,body,url --limit 100)
+
+    # Sort by priority (P1 < P2 < P3 < no priority), tiebreak by issue number
+    next=$(echo "$issues" | jq '
+        if length == 0 then null
+        else
+            sort_by([
+                (.labels
+                    | map(select(.name | test("^P[0-9]+$")))
+                    | if length > 0 then (.[0].name[1:] | tonumber) else 999 end),
+                .number
+            ]) | .[0]
+        end
+    ')
+
+    if [[ "$next" == "null" || -z "$next" ]]; then
+        echo "Nothing to do; no remaining issues with labels: $labels"
+        exit 2
+    fi
+
+    # Extract issue details
+    number=$(echo "$next" | jq -r '.number')
+    title=$(echo "$next" | jq -r '.title')
+    url=$(echo "$next" | jq -r '.url')
+    body=$(echo "$next" | jq -r '.body')
+
+    echo "=== Tackling issue #${number}: ${title} ==="
+    echo "    ${url}"
+    echo ""
+
+    # Build prompt for Claude (just strips leading indentation before passing to bash)
+    prompt=$(cat <<'PROMPT_TEMPLATE'
+    You are being asked to resolve GitHub issue #__NUMBER__ at __URL__.
+
+    The full issue body is appended below. Read the issue, review the codebase,
+    perform any necessary experiments, and then proceed to address it.
+
+    Before making changes, create a new branch from main (e.g. "fix/issue-__NUMBER__"
+    or something descriptive).
+
+    When finished, use the `/codex:rescue` skill to ask Codex to review your work
+    for completeness and correctness. If it reports any issues, fix them and ask for
+    a re-review, continuing until the review is clean.
+
+    Once the issue is fixed and all review feedback addressed, finish as follows:
+
+    1. Create a commit with a brief message explaining the work and mentioning the
+       issue (e.g. "Fix foo bar (closes #__NUMBER__)"). Use a fuller commit body
+       when the one-line summary is insufficient.
+    2. Push the branch and create a pull request.
+    3. Post a comment on issue #__NUMBER__ explaining the work done (including any
+       modifications in response to review feedback) and containing links to the
+       commit and PR. The comment should start with:
+       "Addressed via [`<short-hash>`](<commit-url>) in [PR #<n>](<pr-url>)"
+    4. Close the issue as completed.
+
+    Alternatively, if after investigation you discover the issue cannot be fixed
+    (fundamental limitation, requires refactoring beyond intended scope, etc.):
+
+    1. Use the `/codex:rescue` skill to get a second opinion confirming infeasibility.
+    2. Post a detailed comment on the issue explaining why it cannot be addressed.
+    3. Close the issue as "not planned".
+
+    This escape hatch should rarely be needed — these issues are expected to be
+    tractable.
+
+    --- ISSUE #__NUMBER__: __TITLE__ ---
+
+    __BODY__
+    PROMPT_TEMPLATE
+    )
+
+    # Substitute placeholders with actual issue data
+    prompt="${prompt//__NUMBER__/$number}"
+    prompt="${prompt//__URL__/$url}"
+    prompt="${prompt//__TITLE__/$title}"
+    prompt="${prompt//__BODY__/$body}"
+
+    # Launch Claude in autonomous mode
+    claude -p "$prompt" --dangerously-skip-permissions
+
+# Convenience: tackle next plugin issue (always includes claude-code-plugin label)
+tackle-next-plugin-issue *labels:
+    just have-claude-tackle-next-issue-with-labels claude-code-plugin {{labels}}
+
+# Tackle all open issues matching the given labels, one at a time
+have-claude-tackle-all-issues-with-labels *labels:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    iteration=0
+    while true; do
+        iteration=$((iteration + 1))
+
+        # Return to main between iterations for a clean starting state
+        if [[ $iteration -gt 1 ]]; then
+            echo ""
+            echo "=== Returning to main branch ==="
+            git checkout main 2>/dev/null || true
+            git pull --ff-only 2>/dev/null || true
+            echo ""
+        fi
+
+        set +e
+        just have-claude-tackle-next-issue-with-labels {{labels}}
+        code=$?
+        set -e
+
+        case $code in
+            0)
+                echo ""
+                echo "=== Issue resolved (iteration #${iteration}). Checking for more... ==="
+                ;;
+            2)
+                echo ""
+                if [[ $iteration -eq 1 ]]; then
+                    echo "=== Nothing to do — no matching issues found. ==="
+                else
+                    echo "=== All done! Resolved $((iteration - 1)) issue(s). ==="
+                fi
+                exit 0
+                ;;
+            *)
+                echo ""
+                echo "=== Error (exit code $code) on iteration #${iteration}. Stopping. ==="
+                exit $code
+                ;;
+        esac
+    done
+
+# Convenience: tackle all plugin issues (always includes claude-code-plugin label)
+tackle-all-plugin-issues *labels:
+    just have-claude-tackle-all-issues-with-labels claude-code-plugin {{labels}}

--- a/justfile
+++ b/justfile
@@ -56,8 +56,10 @@ have-claude-tackle-next-issue-with-labels *labels:
     echo "    ${url}"
     echo ""
 
-    # Build prompt for Claude (just strips leading indentation before passing to bash)
-    prompt=$(cat <<'PROMPT_TEMPLATE'
+    # Build prompt for Claude
+    # NOTE: cannot use $(cat <<'DELIM' ... DELIM) because bash's parser matches
+    # parentheses inside the heredoc against the $(...) before the heredoc starts.
+    read -r -d '' prompt <<'PROMPT_TEMPLATE' || true
     You are being asked to resolve GitHub issue #__NUMBER__ at __URL__.
 
     The full issue body is appended below. Read the issue, review the codebase,
@@ -89,14 +91,13 @@ have-claude-tackle-next-issue-with-labels *labels:
     2. Post a detailed comment on the issue explaining why it cannot be addressed.
     3. Close the issue as "not planned".
 
-    This escape hatch should rarely be needed — these issues are expected to be
+    This escape hatch should rarely be needed -- these issues are expected to be
     tractable.
 
     --- ISSUE #__NUMBER__: __TITLE__ ---
 
     __BODY__
     PROMPT_TEMPLATE
-    )
 
     # Substitute placeholders with actual issue data
     prompt="${prompt//__NUMBER__/$number}"

--- a/justfile
+++ b/justfile
@@ -65,27 +65,33 @@ have-claude-tackle-next-issue-with-labels *labels:
     The full issue body is appended below. Read the issue, review the codebase,
     perform any necessary experiments, and then proceed to address it.
 
-    Before making changes, create a new branch from main (e.g. "fix/issue-__NUMBER__"
-    or something descriptive).
+    Work on the current branch -- do NOT create a new branch or switch branches.
 
     When finished, use the `/codex:rescue` skill to ask Codex to review your work
     for completeness and correctness. If it reports any issues, fix them and ask for
     a re-review, continuing until the review is clean.
 
-    Once the issue is fixed and all review feedback addressed, finish as follows:
+    Once the issue is fixed and all review feedback addressed, you MUST complete
+    all of the following steps before exiting:
 
-    1. Create a commit with a brief message explaining the work and mentioning the
-       issue (e.g. "Fix foo bar (closes #__NUMBER__)"). Use a fuller commit body
-       when the one-line summary is insufficient.
-    2. Push the branch and create a pull request.
-    3. Post a comment on issue #__NUMBER__ explaining the work done (including any
-       modifications in response to review feedback) and containing links to the
-       commit and PR. The comment should start with:
-       "Addressed via [`<short-hash>`](<commit-url>) in [PR #<n>](<pr-url>)"
-    4. Close the issue as completed.
+    1. Stage and commit all changes with a brief message explaining the work and
+       mentioning the issue, e.g. "Fix foo bar (gh issue: #__NUMBER__)". Add a
+       fuller explanation in the commit body when the one-line summary is not
+       sufficiently detailed.
+    2. Push the current branch to the remote.
+    3. If there is no open pull request for this branch, create one.
+    4. Post a comment on issue #__NUMBER__ explaining the work done, including any
+       modifications made in response to review feedback. The comment should start
+       with "Addressed via [`<short-hash>`](<commit-url>) in [PR #<n>](<pr-url>)"
+       where the commit hash links to the commit on GitHub and the PR reference
+       links to the pull request.
+    5. Close issue #__NUMBER__ as completed.
+
+    Do NOT skip the commit, push, or issue-comment steps -- they are required.
 
     Alternatively, if after investigation you discover the issue cannot be fixed
-    (fundamental limitation, requires refactoring beyond intended scope, etc.):
+    at all -- e.g. fundamental limitation, or would require refactoring well beyond
+    the intended scope -- you may instead:
 
     1. Use the `/codex:rescue` skill to get a second opinion confirming infeasibility.
     2. Post a detailed comment on the issue explaining why it cannot be addressed.
@@ -121,12 +127,7 @@ have-claude-tackle-all-issues-with-labels *labels:
     while true; do
         iteration=$((iteration + 1))
 
-        # Return to main between iterations for a clean starting state
         if [[ $iteration -gt 1 ]]; then
-            echo ""
-            echo "=== Returning to main branch ==="
-            git checkout main 2>/dev/null || true
-            git pull --ff-only 2>/dev/null || true
             echo ""
         fi
 

--- a/plugins/agentic-navigation-guide/.claude-plugin/plugin.json
+++ b/plugins/agentic-navigation-guide/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "agentic-navigation-guide",
+  "description": "Skills, hooks, and agents for maintaining agentic navigation guides — hand-written partial file listings that help AI assistants navigate codebases",
+  "version": "1.0.0",
+  "author": { "name": "plx", "email": "plxgithub@gmail.com" },
+  "repository": "https://github.com/plx/agentic-navigation-guide",
+  "license": "MIT",
+  "keywords": ["navigation", "codebase", "documentation", "file-structure"]
+}

--- a/plugins/agentic-navigation-guide/agents/nav-guide-evaluator.md
+++ b/plugins/agentic-navigation-guide/agents/nav-guide-evaluator.md
@@ -1,0 +1,41 @@
+---
+name: nav-guide-evaluator
+description: Lightweight evaluator for navigation guide decisions — file/directory inclusion, description quality, and structure evaluation. Used by utility skills that need fast, cheap assessments.
+model: haiku
+tools: Read Glob Grep Bash
+maxTurns: 10
+---
+
+You are a navigation guide evaluator. Your job is to make quick, accurate decisions about files and directories in the context of agentic navigation guides.
+
+## What Navigation Guides Are
+
+Navigation guides are hand-written partial file listings that help AI coding assistants navigate codebases efficiently. They live in `AGENTIC_NAVIGATION_GUIDE.md` files and use a structured format:
+
+```
+<agentic-navigation-guide>
+- src/
+  - main.rs # Entry point
+  - lib.rs # Core logic
+  - utils/ # Shared utilities
+- Cargo.toml
+- ... # Other project files
+</agentic-navigation-guide>
+```
+
+Key format rules:
+- Directories end with `/`
+- Comments after `#` describe the item's purpose
+- `...` indicates unlisted items
+- Indentation reflects nesting
+- Only include items that aid navigation — not every file
+
+## Your Evaluation Principles
+
+1. **Navigational value**: Would an AI assistant benefit from knowing about this item? Files that define core abstractions, entry points, configuration, or APIs have high navigational value. Generated files, test fixtures, build artifacts, and boilerplate do not.
+
+2. **Brevity**: When writing descriptions, aim for under 60 characters. Capture the item's primary purpose, not implementation details. Think "what would help someone decide whether to read this file?"
+
+3. **Accuracy**: Descriptions must reflect current file contents. A description that was once accurate but no longer matches is worse than no description.
+
+4. **Structured output**: Always respond in the format requested by the skill prompt. Be decisive — avoid hedging or lengthy explanations.

--- a/plugins/agentic-navigation-guide/agents/nav-guide-worker.md
+++ b/plugins/agentic-navigation-guide/agents/nav-guide-worker.md
@@ -1,0 +1,79 @@
+---
+name: nav-guide-worker
+description: Navigation guide authoring and auditing agent. Used by generate-guide and audit-guide skills for multi-step guide creation and review workflows.
+model: sonnet
+tools: Read Glob Grep Bash Write Edit Agent
+maxTurns: 50
+---
+
+You are a navigation guide author and auditor. You create and maintain agentic navigation guides — hand-written partial file listings that help AI coding assistants navigate codebases.
+
+## Navigation Guide Format
+
+Guides live in `AGENTIC_NAVIGATION_GUIDE.md` files wrapped in XML tags:
+
+```
+<agentic-navigation-guide>
+- src/
+  - main.rs # Entry point
+  - lib.rs # Core logic
+  - utils/ # Shared utilities
+    - config.rs # Configuration loading
+- Cargo.toml
+- README.md
+- ... # Other project files
+</agentic-navigation-guide>
+```
+
+Format rules:
+- Each entry is a list item starting with `- `
+- Directories end with `/`; files do not
+- Optional comment after `#` (first unescaped `#`)
+- Indentation (2 spaces) reflects directory nesting
+- `...` with comment = placeholder for unlisted or future items
+- `...` without comment = must refer to at least one unlisted item in the parent
+- No blank lines within the guide block
+- Choice expansions: `Foo[.h, .cpp]` expands to `Foo.h` and `Foo.cpp`
+- Paths must be relative, no `.` or `..` components, no `//`
+
+## What to Include
+
+Navigation guides are *selective*, not exhaustive. Include items that:
+- Define core abstractions, APIs, or entry points
+- Would help an AI assistant locate relevant code for common tasks
+- Represent important configuration or project structure
+- Are non-obvious or would be hard to find by name alone
+
+Exclude:
+- Generated files, build artifacts, lock files
+- Test fixtures and sample data (unless they define test contracts)
+- Boilerplate files that follow framework conventions
+- Files that are obvious from their directory name (e.g., `index.ts` in a directory already listed)
+- IDE/editor configuration
+
+## Writing Descriptions
+
+- Under 60 characters when possible
+- Capture primary purpose, not implementation details
+- Use active voice: "Parses config files" not "This file is used to parse configuration"
+- Be specific: "OAuth2 token refresh" not "Authentication helpers"
+
+## Workflow
+
+When generating a guide:
+1. Survey the project structure (use `ls`, `find`, or glob)
+2. Evaluate whether flat or nested guides are appropriate
+3. For each candidate item, decide include/exclude based on navigational value
+4. Write terse, accurate descriptions
+5. Validate with `agentic-navigation-guide verify`
+
+When auditing a guide:
+1. Run `agentic-navigation-guide verify` for structural validity
+2. Check each description against current file contents
+3. Look for missing high-value items
+4. Report issues with specific line references
+
+When repairing a guide:
+1. Understand what changed (file added, removed, renamed, moved)
+2. Make the minimal edit to restore validity
+3. Run `agentic-navigation-guide verify` to confirm the fix

--- a/plugins/agentic-navigation-guide/agents/nav-guide-worker.md
+++ b/plugins/agentic-navigation-guide/agents/nav-guide-worker.md
@@ -65,10 +65,10 @@ When generating a guide:
 2. Evaluate whether flat or nested guides are appropriate
 3. For each candidate item, decide include/exclude based on navigational value
 4. Write terse, accurate descriptions
-5. Validate with `agentic-navigation-guide verify`
+5. Validate with `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>`
 
 When auditing a guide:
-1. Run `agentic-navigation-guide verify` for structural validity
+1. Run `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>` for structural validity
 2. Check each description against current file contents
 3. Look for missing high-value items
 4. Report issues with specific line references
@@ -76,4 +76,6 @@ When auditing a guide:
 When repairing a guide:
 1. Understand what changed (file added, removed, renamed, moved)
 2. Make the minimal edit to restore validity
-3. Run `agentic-navigation-guide verify` to confirm the fix
+3. Run `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>` to confirm the fix
+
+**Important:** Always pass explicit `--guide` and `--root` flags to `verify`. Never rely on CLI defaults — the agent's working directory may not match the guide's location, especially in monorepos or with non-default guide filenames.

--- a/plugins/agentic-navigation-guide/agents/nav-guide-worker.md
+++ b/plugins/agentic-navigation-guide/agents/nav-guide-worker.md
@@ -29,7 +29,7 @@ Format rules:
 - Each entry is a list item starting with `- `
 - Directories end with `/`; files do not
 - Optional comment after `#` (first unescaped `#`)
-- Indentation (2 spaces) reflects directory nesting
+- Indentation reflects directory nesting (any consistent unit; 2 spaces recommended)
 - `...` with comment = placeholder for unlisted or future items
 - `...` without comment = must refer to at least one unlisted item in the parent
 - No blank lines within the guide block

--- a/plugins/agentic-navigation-guide/bin/verify-guide.sh
+++ b/plugins/agentic-navigation-guide/bin/verify-guide.sh
@@ -145,15 +145,15 @@ if [[ "$BROAD" == "true" ]]; then
   fi
 
   # Extract paths from both guide and dump, compare for new items
-  # Guide paths: lines matching "- <path>" pattern
-  GUIDE_PATHS="$(grep -oP '(?<=- )[^\s#]+' "$GUIDE_PATH" 2>/dev/null | sort)" || true
-  DUMP_PATHS="$(echo "$DUMP_OUTPUT" | grep -oP '(?<=- )[^\s#]+' 2>/dev/null | sort)" || true
+  # Guide paths: lines matching "- <path>" pattern (POSIX-portable, no grep -P)
+  GUIDE_PATHS="$(sed -n 's/^[[:space:]]*- \([^[:space:]#][^[:space:]#]*\).*/\1/p' "$GUIDE_PATH" | sort)"
+  DUMP_PATHS="$(echo "$DUMP_OUTPUT" | sed -n 's/^[[:space:]]*- \([^[:space:]#][^[:space:]#]*\).*/\1/p' | sort)"
 
   # Find paths in dump but not in guide (potential additions)
-  NEW_PATHS="$(comm -23 <(echo "$DUMP_PATHS") <(echo "$GUIDE_PATHS") 2>/dev/null)" || true
+  NEW_PATHS="$(comm -23 <(echo "$DUMP_PATHS") <(echo "$GUIDE_PATHS"))" || true
 
   # Filter out placeholder markers and common noise
-  NEW_PATHS="$(echo "$NEW_PATHS" | grep -v '^\.\.\.$' | grep -v '^\s*$')" || true
+  NEW_PATHS="$(echo "$NEW_PATHS" | grep -v '^\.\.\.$' | grep -v '^[[:space:]]*$')" || true
 
   if [[ -n "$NEW_PATHS" ]]; then
     COUNT="$(echo "$NEW_PATHS" | wc -l | tr -d ' ')"

--- a/plugins/agentic-navigation-guide/bin/verify-guide.sh
+++ b/plugins/agentic-navigation-guide/bin/verify-guide.sh
@@ -7,7 +7,7 @@
 # nearest navigation guide, and verifies it.
 #
 # Exit codes:
-#   0 — guide is valid (or no guide exists) — completely silent
+#   0 — guide is valid (or no guide/binary exists) — silent unless binary missing
 #   2 — guide is invalid — stderr contains issues + repair suggestion
 #
 # Usage:
@@ -73,7 +73,8 @@ elif [[ -f "$GUIDE_ROOT/Cargo.toml" ]] && command -v cargo &>/dev/null; then
 fi
 
 if [[ ${#ANG_BIN[@]} -eq 0 ]]; then
-  # Can't find the tool — exit silently rather than block the user
+  # Can't find the tool — warn but don't block the user
+  echo "warning: verify-guide.sh: 'agentic-navigation-guide' binary not found on PATH; skipping verification" >&2
   exit 0
 fi
 

--- a/plugins/agentic-navigation-guide/bin/verify-guide.sh
+++ b/plugins/agentic-navigation-guide/bin/verify-guide.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# verify-guide.sh — Hook script for validating navigation guides
+#
+# Called by Claude Code hooks after file operations (PostToolUse) and
+# at the end of a turn (Stop). Reads hook JSON from stdin, finds the
+# nearest navigation guide, and verifies it.
+#
+# Exit codes:
+#   0 — guide is valid (or no guide exists) — completely silent
+#   2 — guide is invalid — stderr contains issues + repair suggestion
+#
+# Usage:
+#   <hook-json> | verify-guide.sh          # narrow check (PostToolUse)
+#   <hook-json> | verify-guide.sh --broad  # broad check (Stop)
+
+set -euo pipefail
+
+BROAD=false
+if [[ "${1:-}" == "--broad" ]]; then
+  BROAD=true
+fi
+
+# ---------------------------------------------------------------------------
+# Parse hook input from stdin
+# ---------------------------------------------------------------------------
+
+INPUT="$(cat)"
+
+# Extract cwd from hook JSON; fall back to PWD if jq unavailable or field missing
+if command -v jq &>/dev/null; then
+  CWD="$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)" || true
+fi
+CWD="${CWD:-$PWD}"
+
+# ---------------------------------------------------------------------------
+# Locate the nearest navigation guide by walking up from CWD
+# ---------------------------------------------------------------------------
+
+GUIDE_NAME="AGENTIC_NAVIGATION_GUIDE.md"
+GUIDE_PATH=""
+GUIDE_ROOT=""
+
+search_dir="$CWD"
+while true; do
+  if [[ -f "$search_dir/$GUIDE_NAME" ]]; then
+    GUIDE_PATH="$search_dir/$GUIDE_NAME"
+    GUIDE_ROOT="$search_dir"
+    break
+  fi
+  parent="$(dirname "$search_dir")"
+  if [[ "$parent" == "$search_dir" ]]; then
+    break  # reached filesystem root
+  fi
+  search_dir="$parent"
+done
+
+# No guide found — nothing to verify, exit silently
+if [[ -z "$GUIDE_PATH" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Locate the agentic-navigation-guide binary
+# ---------------------------------------------------------------------------
+
+ANG_BIN=""
+if command -v agentic-navigation-guide &>/dev/null; then
+  ANG_BIN="agentic-navigation-guide"
+elif [[ -f "$GUIDE_ROOT/Cargo.toml" ]] && command -v cargo &>/dev/null; then
+  # Development fallback: build and run from source
+  ANG_BIN="cargo run --quiet --release --manifest-path $GUIDE_ROOT/Cargo.toml --"
+fi
+
+if [[ -z "$ANG_BIN" ]]; then
+  # Can't find the tool — exit silently rather than block the user
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Narrow check: verify the guide against the filesystem
+# ---------------------------------------------------------------------------
+
+VERIFY_OUTPUT=""
+VERIFY_EXIT=0
+VERIFY_OUTPUT="$($ANG_BIN verify --guide "$GUIDE_PATH" --root "$GUIDE_ROOT" 2>&1)" || VERIFY_EXIT=$?
+
+if [[ $VERIFY_EXIT -eq 0 ]]; then
+  # Guide is valid
+  if [[ "$BROAD" == "false" ]]; then
+    exit 0
+  fi
+  # For broad check, continue to drift detection below
+else
+  # Guide has issues — report them
+  # Build a concise problem description for the repair skill
+  PROBLEMS=""
+  while IFS= read -r line; do
+    # Extract meaningful error lines (skip blank lines and headers)
+    if [[ -n "$line" && "$line" != *"error"*":" && "$line" != *"warning"*":" ]]; then
+      if [[ -n "$PROBLEMS" ]]; then
+        PROBLEMS="$PROBLEMS; $line"
+      else
+        PROBLEMS="$line"
+      fi
+    fi
+  done <<< "$VERIFY_OUTPUT"
+
+  # Truncate if too long
+  if [[ ${#PROBLEMS} -gt 200 ]]; then
+    PROBLEMS="${PROBLEMS:0:197}..."
+  fi
+
+  RELATIVE_GUIDE="${GUIDE_PATH#$CWD/}"
+  if [[ "$RELATIVE_GUIDE" == "$GUIDE_PATH" ]]; then
+    RELATIVE_GUIDE="${GUIDE_PATH#$GUIDE_ROOT/}"
+  fi
+
+  cat >&2 <<EOF
+Navigation guide is out of sync.
+
+Issues:
+$VERIFY_OUTPUT
+
+Invoke the navigation-guide-repair skill to fix this:
+  Use the Skill tool with skill: "agentic-navigation-guide:navigation-guide-repair", args: "$RELATIVE_GUIDE '$PROBLEMS'"
+EOF
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Broad check: detect drift (new files that should be in the guide)
+# ---------------------------------------------------------------------------
+
+if [[ "$BROAD" == "true" ]]; then
+  # Get current filesystem listing (depth 2)
+  DUMP_OUTPUT=""
+  DUMP_OUTPUT="$($ANG_BIN dump --depth 2 --root "$GUIDE_ROOT" \
+    --exclude .git --exclude node_modules --exclude target \
+    --exclude build --exclude dist --exclude __pycache__ \
+    --exclude .venv 2>/dev/null)" || true
+
+  if [[ -z "$DUMP_OUTPUT" ]]; then
+    exit 0
+  fi
+
+  # Extract paths from both guide and dump, compare for new items
+  # Guide paths: lines matching "- <path>" pattern
+  GUIDE_PATHS="$(grep -oP '(?<=- )[^\s#]+' "$GUIDE_PATH" 2>/dev/null | sort)" || true
+  DUMP_PATHS="$(echo "$DUMP_OUTPUT" | grep -oP '(?<=- )[^\s#]+' 2>/dev/null | sort)" || true
+
+  # Find paths in dump but not in guide (potential additions)
+  NEW_PATHS="$(comm -23 <(echo "$DUMP_PATHS") <(echo "$GUIDE_PATHS") 2>/dev/null)" || true
+
+  # Filter out placeholder markers and common noise
+  NEW_PATHS="$(echo "$NEW_PATHS" | grep -v '^\.\.\.$' | grep -v '^\s*$')" || true
+
+  if [[ -n "$NEW_PATHS" ]]; then
+    COUNT="$(echo "$NEW_PATHS" | wc -l | tr -d ' ')"
+
+    RELATIVE_GUIDE="${GUIDE_PATH#$CWD/}"
+    if [[ "$RELATIVE_GUIDE" == "$GUIDE_PATH" ]]; then
+      RELATIVE_GUIDE="${GUIDE_PATH#$GUIDE_ROOT/}"
+    fi
+
+    cat >&2 <<EOF
+Navigation guide may be out of date — $COUNT new item(s) detected on disk but not in the guide.
+
+New items:
+$(echo "$NEW_PATHS" | head -20 | sed 's/^/  - /')
+
+Consider running the audit-guide skill for a thorough review:
+  Use the Skill tool with skill: "agentic-navigation-guide:audit-guide", args: "$RELATIVE_GUIDE"
+EOF
+    exit 2
+  fi
+fi
+
+exit 0

--- a/plugins/agentic-navigation-guide/bin/verify-guide.sh
+++ b/plugins/agentic-navigation-guide/bin/verify-guide.sh
@@ -144,16 +144,21 @@ if [[ "$BROAD" == "true" ]]; then
     exit 0
   fi
 
-  # Extract paths from both guide and dump, compare for new items
-  # Guide paths: lines matching "- <path>" pattern (POSIX-portable, no grep -P)
-  GUIDE_PATHS="$(sed -n 's/^[[:space:]]*- \([^[:space:]#][^[:space:]#]*\).*/\1/p' "$GUIDE_PATH" | sort)"
-  DUMP_PATHS="$(echo "$DUMP_OUTPUT" | sed -n 's/^[[:space:]]*- \([^[:space:]#][^[:space:]#]*\).*/\1/p' | sort)"
+  # Extract paths from both guide and dump using the CLI's parser (handles
+  # spaces in paths, escaped # characters, and other edge cases correctly).
+  GUIDE_PATHS="$($ANG_BIN verify --format paths --guide "$GUIDE_PATH" 2>/dev/null | sort)" || true
+
+  # Write dump output to a temp file so the CLI can parse it
+  DUMP_TMPFILE="$(mktemp)"
+  trap 'rm -f "$DUMP_TMPFILE"' EXIT
+  echo "$DUMP_OUTPUT" > "$DUMP_TMPFILE"
+  DUMP_PATHS="$($ANG_BIN verify --format paths --guide "$DUMP_TMPFILE" 2>/dev/null | sort)" || true
 
   # Find paths in dump but not in guide (potential additions)
   NEW_PATHS="$(comm -23 <(echo "$DUMP_PATHS") <(echo "$GUIDE_PATHS"))" || true
 
-  # Filter out placeholder markers and common noise
-  NEW_PATHS="$(echo "$NEW_PATHS" | grep -v '^\.\.\.$' | grep -v '^[[:space:]]*$')" || true
+  # Filter out blank lines (--format paths already omits placeholders)
+  NEW_PATHS="$(echo "$NEW_PATHS" | grep -v '^[[:space:]]*$')" || true
 
   if [[ -n "$NEW_PATHS" ]]; then
     COUNT="$(echo "$NEW_PATHS" | wc -l | tr -d ' ')"

--- a/plugins/agentic-navigation-guide/bin/verify-guide.sh
+++ b/plugins/agentic-navigation-guide/bin/verify-guide.sh
@@ -64,15 +64,15 @@ fi
 # Locate the agentic-navigation-guide binary
 # ---------------------------------------------------------------------------
 
-ANG_BIN=""
+ANG_BIN=()
 if command -v agentic-navigation-guide &>/dev/null; then
-  ANG_BIN="agentic-navigation-guide"
+  ANG_BIN=(agentic-navigation-guide)
 elif [[ -f "$GUIDE_ROOT/Cargo.toml" ]] && command -v cargo &>/dev/null; then
   # Development fallback: build and run from source
-  ANG_BIN="cargo run --quiet --release --manifest-path $GUIDE_ROOT/Cargo.toml --"
+  ANG_BIN=(cargo run --quiet --release --manifest-path "${GUIDE_ROOT}/Cargo.toml" --)
 fi
 
-if [[ -z "$ANG_BIN" ]]; then
+if [[ ${#ANG_BIN[@]} -eq 0 ]]; then
   # Can't find the tool — exit silently rather than block the user
   exit 0
 fi
@@ -83,7 +83,7 @@ fi
 
 VERIFY_OUTPUT=""
 VERIFY_EXIT=0
-VERIFY_OUTPUT="$($ANG_BIN verify --guide "$GUIDE_PATH" --root "$GUIDE_ROOT" 2>&1)" || VERIFY_EXIT=$?
+VERIFY_OUTPUT="$("${ANG_BIN[@]}" verify --guide "$GUIDE_PATH" --root "$GUIDE_ROOT" 2>&1)" || VERIFY_EXIT=$?
 
 if [[ $VERIFY_EXIT -eq 0 ]]; then
   # Guide is valid
@@ -111,9 +111,9 @@ else
     PROBLEMS="${PROBLEMS:0:197}..."
   fi
 
-  RELATIVE_GUIDE="${GUIDE_PATH#$CWD/}"
+  RELATIVE_GUIDE="${GUIDE_PATH#"$CWD"/}"
   if [[ "$RELATIVE_GUIDE" == "$GUIDE_PATH" ]]; then
-    RELATIVE_GUIDE="${GUIDE_PATH#$GUIDE_ROOT/}"
+    RELATIVE_GUIDE="${GUIDE_PATH#"$GUIDE_ROOT"/}"
   fi
 
   cat >&2 <<EOF
@@ -135,7 +135,7 @@ fi
 if [[ "$BROAD" == "true" ]]; then
   # Get current filesystem listing (depth 2)
   DUMP_OUTPUT=""
-  DUMP_OUTPUT="$($ANG_BIN dump --depth 2 --root "$GUIDE_ROOT" \
+  DUMP_OUTPUT="$("${ANG_BIN[@]}" dump --depth 2 --root "$GUIDE_ROOT" \
     --exclude .git --exclude node_modules --exclude target \
     --exclude build --exclude dist --exclude __pycache__ \
     --exclude .venv 2>/dev/null)" || true
@@ -146,13 +146,13 @@ if [[ "$BROAD" == "true" ]]; then
 
   # Extract paths from both guide and dump using the CLI's parser (handles
   # spaces in paths, escaped # characters, and other edge cases correctly).
-  GUIDE_PATHS="$($ANG_BIN verify --format paths --guide "$GUIDE_PATH" 2>/dev/null | sort)" || true
+  GUIDE_PATHS="$("${ANG_BIN[@]}" verify --format paths --guide "$GUIDE_PATH" 2>/dev/null | sort)" || true
 
   # Write dump output to a temp file so the CLI can parse it
   DUMP_TMPFILE="$(mktemp)"
   trap 'rm -f "$DUMP_TMPFILE"' EXIT
   echo "$DUMP_OUTPUT" > "$DUMP_TMPFILE"
-  DUMP_PATHS="$($ANG_BIN verify --format paths --guide "$DUMP_TMPFILE" 2>/dev/null | sort)" || true
+  DUMP_PATHS="$("${ANG_BIN[@]}" verify --format paths --guide "$DUMP_TMPFILE" 2>/dev/null | sort)" || true
 
   # Find paths in dump but not in guide (potential additions)
   NEW_PATHS="$(comm -23 <(echo "$DUMP_PATHS") <(echo "$GUIDE_PATHS"))" || true
@@ -163,9 +163,9 @@ if [[ "$BROAD" == "true" ]]; then
   if [[ -n "$NEW_PATHS" ]]; then
     COUNT="$(echo "$NEW_PATHS" | wc -l | tr -d ' ')"
 
-    RELATIVE_GUIDE="${GUIDE_PATH#$CWD/}"
+    RELATIVE_GUIDE="${GUIDE_PATH#"$CWD"/}"
     if [[ "$RELATIVE_GUIDE" == "$GUIDE_PATH" ]]; then
-      RELATIVE_GUIDE="${GUIDE_PATH#$GUIDE_ROOT/}"
+      RELATIVE_GUIDE="${GUIDE_PATH#"$GUIDE_ROOT"/}"
     fi
 
     cat >&2 <<EOF

--- a/plugins/agentic-navigation-guide/bin/verify-guide.sh
+++ b/plugins/agentic-navigation-guide/bin/verify-guide.sh
@@ -67,14 +67,14 @@ fi
 ANG_BIN=()
 if command -v agentic-navigation-guide &>/dev/null; then
   ANG_BIN=(agentic-navigation-guide)
-elif [[ -f "$GUIDE_ROOT/Cargo.toml" ]] && command -v cargo &>/dev/null; then
-  # Development fallback: build and run from source
-  ANG_BIN=(cargo run --quiet --release --manifest-path "${GUIDE_ROOT}/Cargo.toml" --)
+elif [[ -x "$GUIDE_ROOT/target/release/agentic-navigation-guide" ]]; then
+  # Use pre-built binary from target/release/ if available
+  ANG_BIN=("$GUIDE_ROOT/target/release/agentic-navigation-guide")
 fi
 
 if [[ ${#ANG_BIN[@]} -eq 0 ]]; then
   # Can't find the tool — warn but don't block the user
-  echo "warning: verify-guide.sh: 'agentic-navigation-guide' binary not found on PATH; skipping verification" >&2
+  echo "warning: verify-guide.sh: 'agentic-navigation-guide' binary not found; skipping verification. Run 'cargo build --release' to enable hook verification." >&2
   exit 0
 fi
 

--- a/plugins/agentic-navigation-guide/hooks/hooks.json
+++ b/plugins/agentic-navigation-guide/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/bin/verify-guide.sh",
-            "timeout": 30
+            "timeout": 120
           }
         ]
       }
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/bin/verify-guide.sh --broad",
-            "timeout": 30
+            "timeout": 120
           }
         ]
       }

--- a/plugins/agentic-navigation-guide/hooks/hooks.json
+++ b/plugins/agentic-navigation-guide/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/verify-guide.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/verify-guide.sh --broad",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agentic-navigation-guide/skills/audit-description/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/audit-description/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: audit-description
+description: Check if a file's navigation guide description is still accurate. Returns acceptable/needs-update with suggested replacement.
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep
+---
+
+Evaluate whether an existing navigation guide description for a file is still accurate.
+
+**File path:** $0
+**Current description:** $1
+
+## Instructions
+
+1. Read the file to understand its current purpose and contents
+2. Compare the current description against the file's actual role
+3. A description is **acceptable** if it:
+   - Correctly identifies the file's primary purpose
+   - Is not misleading about what the file contains
+   - Is still relevant (the file hasn't been substantially rewritten)
+4. A description **needs update** if it:
+   - Refers to functionality that has been removed or moved
+   - Misidentifies the file's purpose
+   - Is so vague as to be unhelpful when the file has a clear, specific purpose
+   - Describes a secondary concern while missing the primary one
+
+Note: minor wording preferences are NOT grounds for update. Only flag descriptions that are materially wrong or misleading.
+
+## Response Format
+
+```
+VERDICT: acceptable | needs-update
+CURRENT: <the current description>
+SUGGESTED: <replacement description, or same as current if acceptable>
+REASON: <one sentence if needs-update, omit if acceptable>
+```

--- a/plugins/agentic-navigation-guide/skills/audit-dir-description/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/audit-dir-description/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: audit-dir-description
+description: Check if a directory's navigation guide description is still accurate. Returns acceptable/needs-update with suggested replacement.
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep Bash
+---
+
+Evaluate whether an existing navigation guide description for a directory is still accurate.
+
+**Directory path:** $0
+**Current description:** $1
+
+## Instructions
+
+1. List the directory contents and sample a few files to understand its current purpose
+2. Compare the current description against the directory's actual role
+3. A description is **acceptable** if it correctly characterizes the directory's organizational purpose
+4. A description **needs update** if the directory's contents have shifted significantly from what the description implies
+
+Minor wording preferences are NOT grounds for update. Only flag descriptions that are materially wrong or misleading.
+
+## Response Format
+
+```
+VERDICT: acceptable | needs-update
+CURRENT: <the current description>
+SUGGESTED: <replacement description, or same as current if acceptable>
+REASON: <one sentence if needs-update, omit if acceptable>
+```

--- a/plugins/agentic-navigation-guide/skills/audit-guide/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/audit-guide/SKILL.md
@@ -16,7 +16,7 @@ Audit an existing agentic navigation guide for accuracy and completeness.
 
 ### Phase 1: Structural Validation
 
-1. Run `agentic-navigation-guide verify` against the guide file.
+1. Run `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>` against the guide file, substituting the actual guide path and its parent directory.
 2. If there are structural errors (missing files, wrong types), collect them as the first set of issues.
 
 ### Phase 2: Description Audit
@@ -59,7 +59,7 @@ X structural issues, Y stale descriptions, Z suggested additions
    - Structural issues: remove entries for deleted files, add entries for missing ones
    - Stale descriptions: update descriptions in place
    - Additions: add new entries at appropriate positions
-10. Re-run `agentic-navigation-guide verify` to confirm all fixes are valid.
+10. Re-run `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>` to confirm all fixes are valid.
 
 ## Guidelines
 

--- a/plugins/agentic-navigation-guide/skills/audit-guide/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/audit-guide/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: audit-guide
+description: Audit an existing navigation guide for structural errors and stale descriptions. Runs validation, checks file descriptions against contents, and reports issues.
+context: fork
+agent: nav-guide-worker
+disable-model-invocation: true
+argument-hint: [guide-path]
+allowed-tools: Read Glob Grep Bash Edit Write Agent
+---
+
+Audit an existing agentic navigation guide for accuracy and completeness.
+
+**Guide file:** $ARGUMENTS (defaults to `AGENTIC_NAVIGATION_GUIDE.md` in current directory)
+
+## Workflow
+
+### Phase 1: Structural Validation
+
+1. Run `agentic-navigation-guide verify` against the guide file.
+2. If there are structural errors (missing files, wrong types), collect them as the first set of issues.
+
+### Phase 2: Description Audit
+
+3. Parse the guide to extract all file and directory entries with their descriptions.
+4. For each entry that has a description:
+   - Read the file or directory
+   - Compare the description against the current contents
+   - Flag descriptions that are materially wrong, misleading, or refer to functionality that no longer exists
+5. Do NOT flag descriptions for minor wording preferences — only material inaccuracies.
+
+### Phase 3: Completeness Check
+
+6. Compare the guide against the actual directory structure:
+   - Look for high-value files that exist but are not in the guide (entry points, core types, important configs)
+   - Look for directories that have grown significantly since the guide was written
+7. Only flag truly important omissions — the guide is intentionally selective.
+
+### Phase 4: Report
+
+8. Present findings in three sections:
+
+```
+## Structural Issues
+<issues from verify, if any>
+
+## Stale Descriptions
+<entries where description doesn't match content>
+- line N: path — current: "old description" → suggested: "new description"
+
+## Suggested Additions
+<high-value items missing from the guide>
+- path — reason for inclusion
+
+## Summary
+X structural issues, Y stale descriptions, Z suggested additions
+```
+
+9. If the user confirms, fix the issues:
+   - Structural issues: remove entries for deleted files, add entries for missing ones
+   - Stale descriptions: update descriptions in place
+   - Additions: add new entries at appropriate positions
+10. Re-run `agentic-navigation-guide verify` to confirm all fixes are valid.
+
+## Guidelines
+
+- Be conservative with "stale" verdicts — descriptions that are directionally correct but imprecise should not be flagged
+- For completeness checks, consider recent git history (`git log --oneline -20 --name-only`) to prioritize recently-added files
+- Never remove entries just because they seem unimportant — the author may have included them for a reason

--- a/plugins/agentic-navigation-guide/skills/describe-dir/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/describe-dir/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: describe-dir
+description: Read a directory and produce a terse description suitable for a navigation guide comment (under 60 chars).
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep Bash
+---
+
+Generate a terse description for the following directory, suitable for use as a navigation guide comment.
+
+**Directory to describe:** $ARGUMENTS
+
+## Instructions
+
+1. List the directory contents and read a few representative files to understand its purpose
+2. Write a description that:
+   - Is under 60 characters
+   - Captures the directory's organizational purpose
+   - Uses sentence fragments (no trailing period)
+   - Avoids redundancy with the directory name
+   - Distinguishes this directory from siblings with similar names
+
+## Examples of Good Descriptions
+
+- `# REST API route handlers`
+- `# Database migration scripts`
+- `# Shared React UI components`
+- `# Integration test suites`
+- `# gRPC service definitions and generated stubs`
+
+## Examples of Bad Descriptions
+
+- `# Source code` (too vague for `src/`)
+- `# Tests` (restates the directory name `tests/`)
+- `# Contains the components used in the frontend application` (too wordy)
+
+## Response Format
+
+Respond with exactly one line:
+
+```
+DESCRIPTION: <the description, without the leading #>
+```

--- a/plugins/agentic-navigation-guide/skills/describe-file/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/describe-file/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: describe-file
+description: Read a file and produce a terse description suitable for a navigation guide comment (under 60 chars).
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep
+---
+
+Generate a terse description for the following file, suitable for use as a navigation guide comment.
+
+**File to describe:** $ARGUMENTS
+
+## Instructions
+
+1. Read the file to understand its primary purpose
+2. Write a description that:
+   - Is under 60 characters
+   - Captures the file's primary purpose, not implementation details
+   - Uses sentence fragments, not full sentences (no period at end)
+   - Avoids redundancy with the filename (don't restate what the name already says)
+   - Is specific enough to help decide whether to read the file
+   - Uses active voice when possible
+
+## Examples of Good Descriptions
+
+- `# OAuth2 token refresh and session management`
+- `# CLI argument parsing and subcommand dispatch`
+- `# Templated reusable-resource pool`
+- `# Error types and conversion impls`
+- `# Webpack config for production builds`
+
+## Examples of Bad Descriptions
+
+- `# This file contains utility functions` (too vague)
+- `# Main` (too terse, restates filename)
+- `# Handles various authentication-related operations including login, logout, and token management` (too long)
+- `# Helper file` (meaningless)
+
+## Response Format
+
+Respond with exactly one line:
+
+```
+DESCRIPTION: <the description, without the leading #>
+```

--- a/plugins/agentic-navigation-guide/skills/evaluate-structure/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/evaluate-structure/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: evaluate-structure
+description: Evaluate a project's size and structure to recommend flat vs nested navigation guide strategy, including depth and nesting decisions.
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep Bash
+---
+
+Evaluate the project structure and recommend a navigation guide strategy.
+
+**Project root:** $ARGUMENTS
+
+## Instructions
+
+1. Count total files and directories (excluding `.git/`, `node_modules/`, `target/`, `build/`, `dist/`, `__pycache__/`)
+2. Examine the directory tree to depth 3
+3. Assess complexity and recommend a strategy:
+
+### Flat (Single Guide)
+
+Recommend when:
+- Fewer than ~100 source files
+- Shallow directory structure (1-2 levels of nesting)
+- Single-language project with straightforward layout
+- No independently-navigable subprojects
+
+### Nested (Multiple Guides)
+
+Recommend when:
+- Monorepo with distinct subprojects
+- More than ~200 source files across multiple deep subdirectories
+- Independently-deployable services or packages
+- Subdirectories that have their own build systems or configs
+
+For nested strategies, identify which subdirectories should get their own `AGENTIC_NAVIGATION_GUIDE.md`.
+
+4. Recommend depth for the root guide:
+   - Depth 1: only top-level items (for very large projects or monorepos)
+   - Depth 2: top-level + one level of children (most common)
+   - Depth 3: deeper nesting (small to medium projects with rich structure)
+
+## Response Format
+
+```
+STRATEGY: flat | nested
+ROOT_DEPTH: 1 | 2 | 3
+NESTED_GUIDES: <comma-separated list of subdirectory paths, or "none">
+TOTAL_FILES: <approximate count>
+REASON: <1-2 sentences explaining the recommendation>
+```

--- a/plugins/agentic-navigation-guide/skills/generate-guide/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/generate-guide/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: generate-guide
+description: Generate an initial navigation guide for a project that doesn't have one. Analyzes project structure, evaluates files for inclusion, and writes descriptions.
+context: fork
+agent: nav-guide-worker
+disable-model-invocation: true
+argument-hint: [project-root-path]
+allowed-tools: Read Glob Grep Bash Write Edit Agent
+---
+
+Generate an agentic navigation guide for a project.
+
+**Project root:** $ARGUMENTS (defaults to current working directory if not specified)
+
+## Workflow
+
+### Phase 1: Survey
+
+1. Check if an `AGENTIC_NAVIGATION_GUIDE.md` already exists. If so, warn the user and ask before overwriting.
+2. Run `agentic-navigation-guide dump --depth 3 --exclude .git --exclude node_modules --exclude target --exclude build --exclude dist --exclude __pycache__ --exclude .venv` to get the raw directory structure.
+3. Count the total number of source files to gauge project size.
+
+### Phase 2: Strategy
+
+4. Evaluate the project structure to decide between a flat or nested guide strategy. Consider:
+   - Total file count and directory depth
+   - Whether there are distinct subprojects (monorepo indicators: multiple `package.json`, `Cargo.toml`, `go.mod`, etc.)
+   - Whether any subdirectory is large enough to warrant its own guide
+
+5. For the chosen strategy, determine:
+   - **Flat**: What depth to include, and which top-level items to list
+   - **Nested**: Which directories get their own guides, what depth at each level
+
+### Phase 3: Evaluate Candidates
+
+6. For each directory at the target depth, decide whether to include it. Prioritize directories that:
+   - Contain source code (not build artifacts, caches, or vendored dependencies)
+   - Group related functionality in a non-obvious way
+   - Would help an AI assistant navigate the project
+
+7. For each file at the target depth within included directories, decide whether to include it. Prioritize files that:
+   - Define core types, interfaces, or entry points
+   - Would be hard to find by name alone
+   - Are critical for understanding architecture
+
+8. For file sets (e.g., `.h/.cpp` pairs, `index.ts` + co-located files), evaluate as units and use choice expansion syntax where appropriate (e.g., `FooController[.h, .cpp]`).
+
+### Phase 4: Generate Descriptions
+
+9. For each included item, read it and write a terse description (under 60 characters). Descriptions should:
+   - Capture primary purpose, not implementation details
+   - Avoid redundancy with the filename
+   - Use consistent style across the guide
+
+### Phase 5: Assemble and Validate
+
+10. Assemble the guide in proper format:
+    - Wrap in `<agentic-navigation-guide>` tags
+    - Use 2-space indentation for nesting
+    - Add `- ... # Additional project files` at appropriate levels
+    - Ensure directories end with `/`
+
+11. Write to `AGENTIC_NAVIGATION_GUIDE.md` (or the nested guide location).
+
+12. Run `agentic-navigation-guide verify` to validate. Fix any errors.
+
+13. Report a summary: how many items included, strategy chosen, and any notable exclusions.
+
+## Guidelines
+
+- Aim for 10-30 entries in a single guide. Under 10 is too sparse; over 50 is too noisy.
+- When in doubt, exclude. A smaller, accurate guide is better than a large, stale one.
+- Match the description style to any existing guides in the project.
+- For monorepos, generate the root guide first, then offer to generate nested guides.

--- a/plugins/agentic-navigation-guide/skills/generate-guide/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/generate-guide/SKILL.md
@@ -62,7 +62,7 @@ Generate an agentic navigation guide for a project.
 
 11. Write to `AGENTIC_NAVIGATION_GUIDE.md` (or the nested guide location).
 
-12. Run `agentic-navigation-guide verify` to validate. Fix any errors.
+12. Run `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>` to validate, substituting the actual output path from step 11 and its parent directory. Fix any errors.
 
 13. Report a summary: how many items included, strategy chosen, and any notable exclusions.
 

--- a/plugins/agentic-navigation-guide/skills/generate-guide/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/generate-guide/SKILL.md
@@ -56,7 +56,7 @@ Generate an agentic navigation guide for a project.
 
 10. Assemble the guide in proper format:
     - Wrap in `<agentic-navigation-guide>` tags
-    - Use 2-space indentation for nesting
+    - Use consistent indentation for nesting (2 spaces recommended)
     - Add `- ... # Additional project files` at appropriate levels
     - Ensure directories end with `/`
 

--- a/plugins/agentic-navigation-guide/skills/guide-search/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/guide-search/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: guide-search
+description: Use a navigation guide to find relevant files and directories for a given topic or task. Returns a prioritized list of places to examine.
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep
+---
+
+Given a search target, use the navigation guide to identify the most relevant files and directories to examine.
+
+**Guide file:** $0
+**Search target:** $1
+
+## Instructions
+
+1. Read the navigation guide file
+2. For each entry in the guide, assess its relevance to the search target based on:
+   - The file/directory path (name matching)
+   - The description comment (semantic matching)
+   - The position in the hierarchy (structural context)
+3. Return a prioritized list of the most relevant entries, ordered by likelihood of containing relevant code
+
+## Response Format
+
+Return up to 10 entries, most relevant first:
+
+```
+RESULTS:
+1. <path> — <reason for relevance>
+2. <path> — <reason for relevance>
+...
+```
+
+If nothing in the guide seems relevant, respond with:
+
+```
+RESULTS: none — <brief suggestion for where else to look>
+```

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: nav-guide-reference
+description: Reference for the agentic-navigation-guide CLI tool and navigation guide format. Activates when working with AGENTIC_NAVIGATION_GUIDE.md files or the agentic-navigation-guide CLI.
+user-invocable: false
+---
+
+# Agentic Navigation Guide — Quick Reference
+
+## What It Is
+
+A **navigation guide** is a hand-written partial file listing that helps AI coding assistants navigate codebases efficiently. It lives in an `AGENTIC_NAVIGATION_GUIDE.md` file and is typically referenced from `CLAUDE.md` via the `@` syntax.
+
+Unlike auto-generated file trees, navigation guides are *selective*: they list only the items an AI assistant needs to know about, with terse descriptions explaining each item's purpose.
+
+## Guide Format
+
+```
+<agentic-navigation-guide>
+- src/
+  - main.rs # Entry point
+  - lib.rs # Core library logic
+  - utils/ # Shared helpers
+- Cargo.toml
+- README.md
+- ... # Other project files
+</agentic-navigation-guide>
+```
+
+- Directories end with `/`
+- Comments follow the first unescaped `#`
+- `...` = placeholder for unlisted items (with comment) or omitted existing items (without)
+- 2-space indentation for nesting
+- No blank lines within the block
+
+For the full format specification, see `format-reference.md` in this skill directory.
+
+## CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `agentic-navigation-guide init` | Generate a starting-point guide from current directory |
+| `agentic-navigation-guide check` | Validate guide syntax (no filesystem check) |
+| `agentic-navigation-guide verify` | Validate guide against actual filesystem |
+| `agentic-navigation-guide dump` | Dump directory tree in guide format |
+
+### Common Flags
+
+```bash
+# Verify with specific guide and root
+agentic-navigation-guide verify --guide path/to/guide.md --root /project
+
+# Dump with depth limit and exclusions
+agentic-navigation-guide dump --depth 3 --exclude target --exclude .git
+
+# Verify recursively (monorepos)
+agentic-navigation-guide verify --recursive --exclude node_modules
+
+# Post-tool-use hook mode (exit code 2 on failure)
+agentic-navigation-guide verify --post-tool-use-hook
+
+# GitHub Actions mode (concise output, file:line format)
+agentic-navigation-guide verify --github-actions-check
+```
+
+## Typical Workflow
+
+1. `agentic-navigation-guide init` — scaffold initial guide
+2. Hand-edit to add descriptions and remove noise
+3. `agentic-navigation-guide verify` — check for errors
+4. Commit and reference from `CLAUDE.md` with `@AGENTIC_NAVIGATION_GUIDE.md`
+
+For advanced usage (environment variables, execution modes, recursive verification, choice expansions), see `advanced-usage.md` in this skill directory.

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
@@ -29,7 +29,7 @@ Unlike auto-generated file trees, navigation guides are *selective*: they list o
 - Directories end with `/`
 - Comments follow the first unescaped `#`
 - `...` = placeholder for unlisted items (with comment) or omitted existing items (without)
-- 2-space indentation for nesting
+- Consistent indentation for nesting (2 spaces recommended; any consistent unit accepted)
 - No blank lines within the block
 
 For the full format specification, see `format-reference.md` in this skill directory.

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
@@ -40,7 +40,7 @@ For the full format specification, see `format-reference.md` in this skill direc
 |---------|---------|
 | `agentic-navigation-guide init --output AGENTIC_NAVIGATION_GUIDE.md` | Generate a starting-point guide from current directory |
 | `agentic-navigation-guide check` | Validate guide syntax (no filesystem check) |
-| `agentic-navigation-guide verify` | Validate guide against actual filesystem |
+| `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>` | Validate guide against actual filesystem |
 | `agentic-navigation-guide dump` | Dump directory tree in guide format |
 
 ### Common Flags
@@ -66,7 +66,7 @@ agentic-navigation-guide verify --github-actions-check
 
 1. `agentic-navigation-guide init --output AGENTIC_NAVIGATION_GUIDE.md` — scaffold initial guide
 2. Hand-edit to add descriptions and remove noise
-3. `agentic-navigation-guide verify` — check for errors
+3. `agentic-navigation-guide verify --guide AGENTIC_NAVIGATION_GUIDE.md --root .` — check for errors
 4. Commit and reference from `CLAUDE.md` with `@AGENTIC_NAVIGATION_GUIDE.md`
 
 For advanced usage (environment variables, execution modes, recursive verification, choice expansions), see `advanced-usage.md` in this skill directory.

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/SKILL.md
@@ -38,7 +38,7 @@ For the full format specification, see `format-reference.md` in this skill direc
 
 | Command | Purpose |
 |---------|---------|
-| `agentic-navigation-guide init` | Generate a starting-point guide from current directory |
+| `agentic-navigation-guide init --output AGENTIC_NAVIGATION_GUIDE.md` | Generate a starting-point guide from current directory |
 | `agentic-navigation-guide check` | Validate guide syntax (no filesystem check) |
 | `agentic-navigation-guide verify` | Validate guide against actual filesystem |
 | `agentic-navigation-guide dump` | Dump directory tree in guide format |
@@ -64,7 +64,7 @@ agentic-navigation-guide verify --github-actions-check
 
 ## Typical Workflow
 
-1. `agentic-navigation-guide init` — scaffold initial guide
+1. `agentic-navigation-guide init --output AGENTIC_NAVIGATION_GUIDE.md` — scaffold initial guide
 2. Hand-edit to add descriptions and remove noise
 3. `agentic-navigation-guide verify` — check for errors
 4. Commit and reference from `CLAUDE.md` with `@AGENTIC_NAVIGATION_GUIDE.md`

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/advanced-usage.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/advanced-usage.md
@@ -1,0 +1,68 @@
+# Advanced Usage
+
+## Environment Variables
+
+| Variable | Purpose | Values |
+|----------|---------|--------|
+| `AGENTIC_NAVIGATION_GUIDE_LOG_MODE` | Output verbosity | `quiet`, `verbose`, `default` |
+| `AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE` | Behavior mode | `post-tool-use`, `pre-commit-hook`, `github-actions`, `default` |
+| `AGENTIC_NAVIGATION_GUIDE_PATH` | Default guide file path | Any file path |
+| `AGENTIC_NAVIGATION_GUIDE_ROOT` | Default root directory | Any directory path |
+| `AGENTIC_NAVIGATION_GUIDE_NAME` | Guide filename for recursive mode | e.g., `GUIDE.md` |
+
+## Execution Modes
+
+- **default**: Standard output, exit code 1 on failure
+- **post-tool-use**: Exit code 2 on failure (signals Claude Code hook system to show error to assistant)
+- **pre-commit-hook**: Exit code 1 on failure (blocks commit)
+- **github-actions**: Concise output with file:line references, emoji indicators
+
+Set via `--post-tool-use-hook`, `--github-actions-check` flags, or `AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE`.
+
+## Recursive Verification (Monorepos)
+
+```bash
+# Discover and verify all AGENTIC_NAVIGATION_GUIDE.md files
+agentic-navigation-guide verify --recursive
+
+# Custom guide filename
+agentic-navigation-guide verify --recursive --guide-name GUIDE.md
+
+# Exclude directories
+agentic-navigation-guide verify --recursive --exclude target --exclude node_modules
+```
+
+Each guide is verified relative to its parent directory.
+
+## Choice Expansions
+
+Combine related file variants on a single line:
+
+```
+- FooController[.h, .cpp] # Manages foo lifecycle
+- Config[, .local].json   # App configuration
+```
+
+Expands to individual entries sharing the same description. At most one choice list per entry.
+
+Escaping: `\,` for literal comma, `\ ` for literal space, `\"` inside quoted values.
+
+## Ignoring Guides
+
+Add `ignore=true` to skip a guide during verification:
+
+```
+<agentic-navigation-guide ignore=true>
+- example/
+  - demo.rs
+</agentic-navigation-guide>
+```
+
+Useful for documentation examples that shouldn't be validated.
+
+## Placeholder Rules
+
+- `...` with comment: Allowed anywhere, even if all items are listed (indicates future items)
+- `...` without comment: Must have at least one unlisted item in parent directory
+- Cannot nest items under `...`
+- Cannot have adjacent `...` entries

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/advanced-usage.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/advanced-usage.md
@@ -8,7 +8,7 @@
 | `AGENTIC_NAVIGATION_GUIDE_EXECUTION_MODE` | Behavior mode | `post-tool-use`, `pre-commit-hook`, `github-actions`, `default` |
 | `AGENTIC_NAVIGATION_GUIDE_PATH` | Default guide file path | Any file path |
 | `AGENTIC_NAVIGATION_GUIDE_ROOT` | Default root directory | Any directory path |
-| `AGENTIC_NAVIGATION_GUIDE_NAME` | Guide filename for recursive mode | e.g., `GUIDE.md` |
+| `AGENTIC_NAVIGATION_GUIDE_NAME` | Default guide filename when `--guide` is not specified (`check`, `verify`, and `verify --recursive`) | e.g., `GUIDE.md` |
 
 ## Execution Modes
 

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/format-reference.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/format-reference.md
@@ -1,0 +1,59 @@
+# Navigation Guide Format Reference
+
+## Structure
+
+A navigation guide is a markdown block wrapped in `<agentic-navigation-guide>` tags containing a hierarchical list of filesystem items.
+
+## Line Format
+
+```
+- [path][/] [# comment]
+```
+
+- **Path**: Relative path component (no `.`, `..`, `//`, or leading `/`)
+- **Trailing `/`**: Marks the entry as a directory
+- **`#` comment**: Optional description (first unescaped `#` starts it; use `\#` for literal)
+- **Indentation**: 2 spaces per nesting level, consistent throughout
+
+## Entry Types
+
+| Syntax | Type | Example |
+|--------|------|---------|
+| `- file.rs` | File | `- main.rs # Entry point` |
+| `- dir/` | Directory | `- src/ # Source code` |
+| `- ...` | Placeholder | `- ... # Other files` |
+
+## Placeholder Rules
+
+| Variant | Requirement |
+|---------|-------------|
+| `... # comment` | Allowed anywhere (even empty dirs) |
+| `...` (no comment) | Parent must have unlisted items |
+
+- No children under `...`
+- No adjacent `...` entries
+
+## Choice Expansions
+
+```
+- Prefix[suffix1, suffix2] # Shared comment
+```
+
+Expands into one entry per option. Max one choice list per line.
+
+## Validation Errors
+
+**Syntax errors** (caught by `check`):
+- Invalid indentation (not a multiple of indent unit)
+- Missing `-` prefix
+- Empty path
+- Path with `.` or `..` components
+- Path with `//` or leading `/`
+- Adjacent placeholders
+- Children under placeholder
+
+**Semantic errors** (caught by `verify`):
+- Path does not exist on filesystem
+- Entry marked as file but is a directory (or vice versa)
+- Uncommented `...` with no unlisted siblings
+- Duplicate entries

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/format-reference.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/format-reference.md
@@ -51,9 +51,9 @@ Expands into one entry per option. Max one choice list per line.
 - Path with `//` or leading `/`
 - Adjacent placeholders
 - Children under placeholder
+- Duplicate entries within the same scope
 
 **Semantic errors** (caught by `verify`):
 - Path does not exist on filesystem
 - Entry marked as file but is a directory (or vice versa)
 - Uncommented `...` with no unlisted siblings
-- Duplicate entries

--- a/plugins/agentic-navigation-guide/skills/nav-guide-reference/format-reference.md
+++ b/plugins/agentic-navigation-guide/skills/nav-guide-reference/format-reference.md
@@ -13,7 +13,7 @@ A navigation guide is a markdown block wrapped in `<agentic-navigation-guide>` t
 - **Path**: Relative path component (no `.`, `..`, `//`, or leading `/`)
 - **Trailing `/`**: Marks the entry as a directory
 - **`#` comment**: Optional description (first unescaped `#` starts it; use `\#` for literal)
-- **Indentation**: 2 spaces per nesting level, consistent throughout
+- **Indentation**: Consistent indent unit per nesting level (2 spaces recommended; tabs, 4 spaces, etc. also accepted)
 
 ## Entry Types
 

--- a/plugins/agentic-navigation-guide/skills/navigation-guide-repair/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/navigation-guide-repair/SKILL.md
@@ -22,7 +22,7 @@ Repair a navigation guide to bring it back in sync with the filesystem.
    - **Renamed/moved**: Remove old entry, add new entry preserving the description
    - **Type change** (file became directory or vice versa): Update the trailing `/`
 4. Preserve existing formatting, indentation, and comment style
-5. Run `agentic-navigation-guide verify` to confirm the fix
+5. Run `agentic-navigation-guide verify --guide <guide-path> --root <guide-parent-directory>` to confirm the fix, substituting the guide path from above and its parent directory
 6. If verification fails, diagnose and fix remaining issues
 
 ## Important

--- a/plugins/agentic-navigation-guide/skills/navigation-guide-repair/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/navigation-guide-repair/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: navigation-guide-repair
+description: Fix a navigation guide based on a specific problem description. Used when hooks or audits detect that a guide has fallen out of sync.
+context: fork
+agent: nav-guide-worker
+user-invocable: false
+allowed-tools: Read Glob Grep Bash Edit Write
+---
+
+Repair a navigation guide to bring it back in sync with the filesystem.
+
+**Guide file:** $0
+**Problem description:** $1
+
+## Instructions
+
+1. Read the current guide file
+2. Understand the problem from the description (e.g., "src/old.rs was removed", "new directory src/auth/ was added")
+3. Make the **minimal edit** needed to fix the issue:
+   - **Removed file/directory**: Remove the corresponding line from the guide
+   - **Added file/directory**: Add a new entry with an appropriate description if the item has navigational value; skip if it doesn't
+   - **Renamed/moved**: Remove old entry, add new entry preserving the description
+   - **Type change** (file became directory or vice versa): Update the trailing `/`
+4. Preserve existing formatting, indentation, and comment style
+5. Run `agentic-navigation-guide verify` to confirm the fix
+6. If verification fails, diagnose and fix remaining issues
+
+## Important
+
+- Do NOT rewrite the entire guide — make targeted fixes only
+- Do NOT change descriptions of items that weren't affected by the problem
+- Do NOT reorder entries unless necessary to fix the issue
+- If adding a new item, match the description style of surrounding entries

--- a/plugins/agentic-navigation-guide/skills/should-include-dir/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/should-include-dir/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: should-include-dir
+description: Decide whether a directory should be included in a navigation guide. Returns a structured include/exclude verdict.
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep Bash
+---
+
+Evaluate whether the following directory should be included in a navigation guide.
+
+**Directory to evaluate:** $ARGUMENTS
+
+## Instructions
+
+1. List the directory contents (immediate children)
+2. Assess navigational value using these criteria:
+
+**Include if the directory:**
+- Contains source code central to the project
+- Groups related functionality (e.g., `src/auth/`, `lib/parsers/`)
+- Contains important configuration or infrastructure code
+- Would help an AI assistant understand project organization
+- Has non-obvious contents that its name doesn't fully explain
+
+**Exclude if the directory:**
+- Is a build output directory (`target/`, `dist/`, `build/`, `node_modules/`)
+- Contains only auto-generated files
+- Is a cache or temporary directory (`.cache/`, `tmp/`)
+- Is a hidden directory with standard tooling config (`.git/`, `.vscode/`)
+- Contains only test fixtures or sample data with no architectural significance
+- Is empty or near-empty with no navigational value
+
+3. If including, also note whether the directory warrants its own entries (children listed in the guide) or just a top-level mention with a description.
+
+## Response Format
+
+```
+VERDICT: include | exclude
+DEPTH: top-level-only | with-children
+REASON: <one sentence explaining why>
+```

--- a/plugins/agentic-navigation-guide/skills/should-include-file/SKILL.md
+++ b/plugins/agentic-navigation-guide/skills/should-include-file/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: should-include-file
+description: Decide whether a file (or file set like .cc/.h pair) should be included in a navigation guide. Returns a structured include/exclude verdict.
+context: fork
+agent: nav-guide-evaluator
+user-invocable: false
+allowed-tools: Read Glob Grep
+---
+
+Evaluate whether the following file(s) should be included in a navigation guide.
+
+**File(s) to evaluate:** $ARGUMENTS
+
+## Instructions
+
+1. Read the file(s) to understand their purpose and content
+2. Assess navigational value using these criteria:
+
+**Include if the file:**
+- Defines core abstractions, types, or interfaces
+- Is an entry point (main, index, app bootstrap)
+- Contains important configuration or constants
+- Defines public APIs or module boundaries
+- Would be non-obvious to find by name alone
+- Is critical for understanding project architecture
+
+**Exclude if the file:**
+- Is auto-generated (lock files, compiled output, bundled assets)
+- Contains only test fixtures, sample data, or mocks
+- Is standard boilerplate that follows framework conventions (e.g., `__init__.py` in every Python package)
+- Is an IDE/editor config file
+- Is a build artifact or cache file
+- Has a name that fully explains its purpose with no additional context needed
+
+3. For file sets (e.g., `.h/.cpp` pairs): evaluate as a unit. If one file in the set has navigational value, include the set.
+
+## Response Format
+
+Respond with exactly this structure:
+
+```
+VERDICT: include | exclude
+REASON: <one sentence explaining why>
+```

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -2,11 +2,22 @@
 
 use agentic_navigation_guide::errors::{AppError, ErrorFormatter, Result};
 use agentic_navigation_guide::parser::Parser;
-use agentic_navigation_guide::types::{Config, ExecutionMode, LogLevel};
+use agentic_navigation_guide::types::{
+    Config, ExecutionMode, FilesystemItem, LogLevel, NavigationGuideLine,
+};
 use agentic_navigation_guide::validator::Validator;
 use agentic_navigation_guide::verifier::Verifier;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use std::path::{Path, PathBuf};
+
+/// Output format for the verify command
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    /// Default human-readable output
+    Default,
+    /// Print parsed paths one per line (directories end with /)
+    Paths,
+}
 
 /// Arguments for the verify subcommand
 #[derive(Args, Debug)]
@@ -24,8 +35,12 @@ pub struct VerifyArgs {
     #[arg(short, long, env = "AGENTIC_NAVIGATION_GUIDE_ROOT")]
     pub root: Option<PathBuf>,
 
+    /// Output format (default: human-readable, paths: one parsed path per line)
+    #[arg(long, value_enum, default_value = "default")]
+    pub format: OutputFormat,
+
     /// Recursively find and verify all navigation guides
-    #[arg(long, conflicts_with = "guide")]
+    #[arg(long, conflicts_with_all = ["guide", "format"])]
     pub recursive: bool,
 
     /// Name of the navigation guide file to search for (only used with --recursive)
@@ -128,6 +143,15 @@ impl VerifyArgs {
                 return Err(e.reported());
             }
         };
+
+        // If --format paths was requested, emit parsed paths and exit early
+        if self.format == OutputFormat::Paths {
+            let paths = collect_paths(&guide.items, "");
+            for path in paths {
+                println!("{path}");
+            }
+            return Ok(());
+        }
 
         // Check if the guide should be ignored
         if guide.ignore {
@@ -375,4 +399,28 @@ fn format_github_actions_error(
     }
 
     output
+}
+
+/// Recursively collect full paths from parsed guide items.
+///
+/// Directories are emitted with a trailing `/`. Placeholders are skipped.
+fn collect_paths(items: &[NavigationGuideLine], prefix: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for item in items {
+        match &item.item {
+            FilesystemItem::Directory { path, children, .. } => {
+                let full = format!("{prefix}{path}/");
+                paths.push(full.clone());
+                paths.extend(collect_paths(children, &full));
+            }
+            FilesystemItem::File { path, .. } => {
+                paths.push(format!("{prefix}{path}"));
+            }
+            FilesystemItem::Symlink { path, .. } => {
+                paths.push(format!("{prefix}{path}"));
+            }
+            FilesystemItem::Placeholder { .. } => {}
+        }
+    }
+    paths
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -44,7 +44,7 @@ pub struct VerifyArgs {
     pub recursive: bool,
 
     /// Name of the navigation guide file to search for (only used with --recursive)
-    #[arg(long, requires = "recursive", env = "AGENTIC_NAVIGATION_GUIDE_NAME")]
+    #[arg(long, requires = "recursive")]
     pub guide_name: Option<String>,
 
     /// Glob patterns to exclude from recursive search (can be specified multiple times)
@@ -259,6 +259,7 @@ impl VerifyArgs {
         // Determine the guide name to search for
         let guide_name = self
             .guide_name
+            .or_else(|| std::env::var("AGENTIC_NAVIGATION_GUIDE_NAME").ok())
             .unwrap_or_else(|| "AGENTIC_NAVIGATION_GUIDE.md".to_string());
 
         log::debug!(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -128,6 +128,14 @@ pub enum SyntaxError {
     /// Placeholder with children
     #[error("line {line}: placeholder entries (...) cannot have child elements")]
     PlaceholderWithChildren { line: usize },
+
+    /// Duplicate entry within the same scope
+    #[error("line {line}: duplicate entry '{path}' (first appeared at line {first_line})")]
+    DuplicateEntry {
+        line: usize,
+        path: String,
+        first_line: usize,
+    },
 }
 
 /// Semantic errors when verifying against filesystem
@@ -201,7 +209,8 @@ impl SyntaxError {
             | Self::InvalidPathFormat { line, .. }
             | Self::InvalidWildcardSyntax { line, .. }
             | Self::AdjacentPlaceholders { line }
-            | Self::PlaceholderWithChildren { line } => Some(*line),
+            | Self::PlaceholderWithChildren { line }
+            | Self::DuplicateEntry { line, .. } => Some(*line),
             Self::EmptyGuideBlock => None,
         }
     }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -2,7 +2,7 @@
 
 use crate::errors::{Result, SyntaxError};
 use crate::types::{FilesystemItem, NavigationGuide, NavigationGuideLine};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path};
 
 /// Validator for navigation guide syntax
@@ -28,6 +28,9 @@ impl Validator {
 
         // Validate indentation consistency
         self.validate_indentation(&guide.items)?;
+
+        // Check for duplicate entries within each scope
+        self.validate_no_duplicates(&guide.items)?;
 
         Ok(())
     }
@@ -218,6 +221,32 @@ impl Validator {
             }
         }
 
+        Ok(())
+    }
+
+    /// Check for duplicate entries within the same scope (sibling level)
+    fn validate_no_duplicates(&self, items: &[NavigationGuideLine]) -> Result<()> {
+        let mut seen: HashMap<&str, usize> = HashMap::new();
+        for item in items {
+            if item.is_placeholder() {
+                continue;
+            }
+            let path = item.path();
+            if let Some(&first_line) = seen.get(path) {
+                return Err(SyntaxError::DuplicateEntry {
+                    line: item.line_number,
+                    path: path.to_string(),
+                    first_line,
+                }
+                .into());
+            }
+            seen.insert(path, item.line_number);
+
+            // Recursively check children of directories
+            if let Some(children) = item.children() {
+                self.validate_no_duplicates(children)?;
+            }
+        }
         Ok(())
     }
 
@@ -498,5 +527,287 @@ mod tests {
         let validator = Validator::new();
         let result = validator.validate_syntax(&guide);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_no_duplicates_passes() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "main.rs".to_string(),
+                comment: None,
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 2,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "lib.rs".to_string(),
+                comment: None,
+            },
+        });
+
+        let validator = Validator::new();
+        assert!(validator.validate_syntax(&guide).is_ok());
+    }
+
+    #[test]
+    fn test_duplicate_root_entries() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "main.rs".to_string(),
+                comment: None,
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 2,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "main.rs".to_string(),
+                comment: Some("duplicate".to_string()),
+            },
+        });
+
+        let validator = Validator::new();
+        let result = validator.validate_syntax(&guide);
+        assert!(matches!(
+            result,
+            Err(crate::errors::AppError::Syntax(
+                SyntaxError::DuplicateEntry {
+                    line: 2,
+                    first_line: 1,
+                    ..
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_nested_entries() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::Directory {
+                path: "src".to_string(),
+                comment: None,
+                children: vec![
+                    NavigationGuideLine {
+                        line_number: 2,
+                        indent_level: 1,
+                        item: FilesystemItem::File {
+                            path: "main.rs".to_string(),
+                            comment: None,
+                        },
+                    },
+                    NavigationGuideLine {
+                        line_number: 3,
+                        indent_level: 1,
+                        item: FilesystemItem::File {
+                            path: "main.rs".to_string(),
+                            comment: None,
+                        },
+                    },
+                ],
+            },
+        });
+
+        let validator = Validator::new();
+        let result = validator.validate_syntax(&guide);
+        assert!(matches!(
+            result,
+            Err(crate::errors::AppError::Syntax(
+                SyntaxError::DuplicateEntry {
+                    line: 3,
+                    first_line: 2,
+                    ..
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_same_name_different_scopes_is_not_duplicate() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "main.rs".to_string(),
+                comment: None,
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 2,
+            indent_level: 0,
+            item: FilesystemItem::Directory {
+                path: "src".to_string(),
+                comment: None,
+                children: vec![NavigationGuideLine {
+                    line_number: 3,
+                    indent_level: 1,
+                    item: FilesystemItem::File {
+                        path: "main.rs".to_string(),
+                        comment: None,
+                    },
+                }],
+            },
+        });
+
+        let validator = Validator::new();
+        assert!(validator.validate_syntax(&guide).is_ok());
+    }
+
+    #[test]
+    fn test_duplicate_directory_entries() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::Directory {
+                path: "src".to_string(),
+                comment: None,
+                children: vec![],
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 2,
+            indent_level: 0,
+            item: FilesystemItem::Directory {
+                path: "src".to_string(),
+                comment: None,
+                children: vec![],
+            },
+        });
+
+        let validator = Validator::new();
+        let result = validator.validate_syntax(&guide);
+        assert!(matches!(
+            result,
+            Err(crate::errors::AppError::Syntax(
+                SyntaxError::DuplicateEntry {
+                    line: 2,
+                    first_line: 1,
+                    ..
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_placeholders_are_not_considered_duplicates() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "main.rs".to_string(),
+                comment: None,
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 2,
+            indent_level: 0,
+            item: FilesystemItem::Placeholder {
+                comment: Some("other files".to_string()),
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 3,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "lib.rs".to_string(),
+                comment: None,
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 4,
+            indent_level: 0,
+            item: FilesystemItem::Placeholder {
+                comment: Some("more files".to_string()),
+            },
+        });
+
+        let validator = Validator::new();
+        // Placeholders would fail adjacency check normally, but here they're
+        // separated by a file. This test verifies placeholders are skipped
+        // by duplicate detection.
+        assert!(validator.validate_syntax(&guide).is_ok());
+    }
+
+    #[test]
+    fn test_duplicate_file_vs_directory_same_name() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "src".to_string(),
+                comment: None,
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 2,
+            indent_level: 0,
+            item: FilesystemItem::Directory {
+                path: "src".to_string(),
+                comment: None,
+                children: vec![],
+            },
+        });
+
+        let validator = Validator::new();
+        let result = validator.validate_syntax(&guide);
+        assert!(matches!(
+            result,
+            Err(crate::errors::AppError::Syntax(
+                SyntaxError::DuplicateEntry {
+                    line: 2,
+                    first_line: 1,
+                    ..
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_entry_reports_correct_path() {
+        let mut guide = NavigationGuide::new();
+        guide.items.push(NavigationGuideLine {
+            line_number: 1,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "lib.rs".to_string(),
+                comment: None,
+            },
+        });
+        guide.items.push(NavigationGuideLine {
+            line_number: 2,
+            indent_level: 0,
+            item: FilesystemItem::File {
+                path: "lib.rs".to_string(),
+                comment: None,
+            },
+        });
+
+        let validator = Validator::new();
+        let result = validator.validate_syntax(&guide);
+        match result {
+            Err(crate::errors::AppError::Syntax(SyntaxError::DuplicateEntry {
+                line,
+                path,
+                first_line,
+            })) => {
+                assert_eq!(line, 2);
+                assert_eq!(first_line, 1);
+                assert_eq!(path, "lib.rs");
+            }
+            other => panic!("expected DuplicateEntry, got: {other:?}"),
+        }
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1726,3 +1726,201 @@ fn test_init_vcs_exclusions_with_user_exclusions() {
         "Should NOT contain node_modules (user-excluded)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --format paths tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_verify_format_paths_basic() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir_path = temp_dir.path();
+
+    // Create filesystem structure
+    fs::create_dir(dir_path.join("src")).unwrap();
+    fs::write(dir_path.join("src/main.rs"), "").unwrap();
+    fs::write(dir_path.join("README.md"), "").unwrap();
+
+    let guide_content = "\
+<agentic-navigation-guide>
+- src/
+  - main.rs
+- README.md
+</agentic-navigation-guide>";
+
+    let guide_path = dir_path.join("GUIDE.md");
+    fs::write(&guide_path, guide_content).unwrap();
+
+    let mut cmd = get_command();
+    let output = cmd
+        .arg("verify")
+        .arg("--format")
+        .arg("paths")
+        .arg("--guide")
+        .arg(&guide_path)
+        .arg("--root")
+        .arg(dir_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(lines, vec!["src/", "src/main.rs", "README.md"]);
+}
+
+#[test]
+fn test_verify_format_paths_with_spaces_in_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir_path = temp_dir.path();
+
+    // Create filesystem with space in directory name
+    fs::create_dir(dir_path.join("my project")).unwrap();
+    fs::write(dir_path.join("my project/notes.txt"), "").unwrap();
+
+    let guide_content = "\
+<agentic-navigation-guide>
+- my project/
+  - notes.txt
+</agentic-navigation-guide>";
+
+    let guide_path = dir_path.join("GUIDE.md");
+    fs::write(&guide_path, guide_content).unwrap();
+
+    let mut cmd = get_command();
+    let output = cmd
+        .arg("verify")
+        .arg("--format")
+        .arg("paths")
+        .arg("--guide")
+        .arg(&guide_path)
+        .arg("--root")
+        .arg(dir_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(lines, vec!["my project/", "my project/notes.txt"]);
+}
+
+#[test]
+fn test_verify_format_paths_with_escaped_hash() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir_path = temp_dir.path();
+
+    // Create file with hash in name
+    fs::write(dir_path.join("config#backup.txt"), "").unwrap();
+
+    let guide_content = "\
+<agentic-navigation-guide>
+- config\\#backup.txt # a backup config
+</agentic-navigation-guide>";
+
+    let guide_path = dir_path.join("GUIDE.md");
+    fs::write(&guide_path, guide_content).unwrap();
+
+    let mut cmd = get_command();
+    let output = cmd
+        .arg("verify")
+        .arg("--format")
+        .arg("paths")
+        .arg("--guide")
+        .arg(&guide_path)
+        .arg("--root")
+        .arg(dir_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // The escaped hash should be resolved to a literal #
+    assert_eq!(lines, vec!["config#backup.txt"]);
+}
+
+#[test]
+fn test_verify_format_paths_skips_placeholders() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir_path = temp_dir.path();
+
+    fs::write(dir_path.join("README.md"), "").unwrap();
+    fs::create_dir(dir_path.join("src")).unwrap();
+
+    let guide_content = "\
+<agentic-navigation-guide>
+- README.md
+- ... # other files
+</agentic-navigation-guide>";
+
+    let guide_path = dir_path.join("GUIDE.md");
+    fs::write(&guide_path, guide_content).unwrap();
+
+    let mut cmd = get_command();
+    let output = cmd
+        .arg("verify")
+        .arg("--format")
+        .arg("paths")
+        .arg("--guide")
+        .arg(&guide_path)
+        .arg("--root")
+        .arg(dir_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Placeholder "..." should not appear in output
+    assert_eq!(lines, vec!["README.md"]);
+}
+
+#[test]
+fn test_verify_format_paths_nested_hierarchy() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir_path = temp_dir.path();
+
+    fs::create_dir_all(dir_path.join("src/cli")).unwrap();
+    fs::write(dir_path.join("src/main.rs"), "").unwrap();
+    fs::write(dir_path.join("src/cli/mod.rs"), "").unwrap();
+    fs::write(dir_path.join("Cargo.toml"), "").unwrap();
+
+    let guide_content = "\
+<agentic-navigation-guide>
+- src/
+  - main.rs
+  - cli/
+    - mod.rs
+- Cargo.toml
+</agentic-navigation-guide>";
+
+    let guide_path = dir_path.join("GUIDE.md");
+    fs::write(&guide_path, guide_content).unwrap();
+
+    let mut cmd = get_command();
+    let output = cmd
+        .arg("verify")
+        .arg("--format")
+        .arg("paths")
+        .arg("--guide")
+        .arg(&guide_path)
+        .arg("--root")
+        .arg(dir_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "src/",
+            "src/main.rs",
+            "src/cli/",
+            "src/cli/mod.rs",
+            "Cargo.toml"
+        ]
+    );
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1924,3 +1924,72 @@ fn test_verify_format_paths_nested_hierarchy() {
         ]
     );
 }
+
+#[test]
+fn test_env_guide_name_in_non_recursive_verify() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Create a guide with a custom name
+    fs::write(root.join("file.txt"), "").unwrap();
+
+    let guide = r#"<agentic-navigation-guide>
+- file.txt
+</agentic-navigation-guide>"#;
+    fs::write(root.join("CUSTOM_GUIDE.md"), guide).unwrap();
+
+    // Non-recursive verify should use the env var as the default guide filename
+    let mut cmd = get_command();
+    cmd.env("AGENTIC_NAVIGATION_GUIDE_NAME", "CUSTOM_GUIDE.md")
+        .arg("verify")
+        .arg("--root")
+        .arg(root)
+        .current_dir(root)
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_env_guide_name_in_non_recursive_check() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    let guide = r#"<agentic-navigation-guide>
+- file.txt
+</agentic-navigation-guide>"#;
+    fs::write(root.join("CUSTOM_GUIDE.md"), guide).unwrap();
+
+    // Non-recursive check should use the env var as the default guide filename
+    let mut cmd = get_command();
+    cmd.env("AGENTIC_NAVIGATION_GUIDE_NAME", "CUSTOM_GUIDE.md")
+        .arg("check")
+        .current_dir(root)
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_env_guide_name_in_recursive_verify() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Create module with custom guide name
+    fs::create_dir_all(root.join("module-a")).unwrap();
+    fs::write(root.join("module-a/file.txt"), "").unwrap();
+
+    let guide = r#"<agentic-navigation-guide>
+- file.txt
+</agentic-navigation-guide>"#;
+    fs::write(root.join("module-a/CUSTOM_GUIDE.md"), guide).unwrap();
+
+    // Recursive verify should use the env var as the default guide filename
+    let mut cmd = get_command();
+    cmd.env("AGENTIC_NAVIGATION_GUIDE_NAME", "CUSTOM_GUIDE.md")
+        .arg("verify")
+        .arg("--recursive")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Found 1 navigation guide(s)"));
+}


### PR DESCRIPTION
## Summary

- Adds a Claude Code plugin (`plugins/agentic-navigation-guide/`) with 12 skills for guide authoring, auditing, repair, file/directory evaluation, description generation, and search
- Includes two agent definitions: a Haiku evaluator for fast decisions and a Sonnet worker for multi-step guide workflows
- Adds PostToolUse and Stop hooks (`verify-guide.sh`) that automatically detect guide drift and suggest repairs
- Adds plugin marketplace catalog (`.claude-plugin/marketplace.json`) and a GitHub Actions workflow for plugin structure validation
- Updates `AGENTIC_NAVIGATION_GUIDE.md` to reflect the new plugin tree

## Test plan

- [ ] Run `cargo test` to confirm existing tests still pass
- [ ] Verify the `validate-plugin` workflow passes in CI (JSON validity, SKILL.md presence, script permissions)
- [ ] Install the plugin locally and confirm hooks fire on file edits
- [ ] Invoke a few skills (e.g., `generate-guide`, `audit-guide`, `navigation-guide-repair`) to verify they work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)